### PR TITLE
Clear stale gateway.pid on startup to prevent crash-loop after redeploy

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -16,4 +16,13 @@ fi
 
 [ ! -f /data/.hermes/.env ] && touch /data/.hermes/.env
 
+# Clear any stale gateway PID file left over from the previous container.
+# `hermes gateway` writes /data/.hermes/gateway.pid on start but does not
+# remove it on SIGTERM. Since /data is a persistent volume, the file
+# survives container restarts and causes every subsequent boot to exit with
+# "ERROR gateway.run: PID file race lost to another gateway instance".
+# No hermes process can be running at this point (we're pre-exec in a fresh
+# container), so removing the file unconditionally is safe.
+rm -f /data/.hermes/gateway.pid
+
 exec python /app/server.py


### PR DESCRIPTION
## Summary

Adds one line to `start.sh` that removes `/data/.hermes/gateway.pid` before exec'ing the wrapper, so the hermes gateway subprocess can start cleanly on every container boot.

## The bug

`hermes gateway` writes its PID to `/data/.hermes/gateway.pid` on startup but does not remove the file on SIGTERM. Because `/data` is a persistent Railway volume, the stale PID file survives container restarts. On every subsequent boot, `hermes gateway` sees the old file, loses its own PID-file race check, and exits immediately:

```
[error] Gateway exited (code 1)
ERROR gateway.run: PID file race lost to another gateway instance. Exiting.
```

Every `restart_policy` retry and every wrapper-managed restart hits the same file and fails the same way. Result: gateway state stays `error`, messaging platforms (Telegram, Slack, Discord, etc.) never come online, and the admin dashboard's "Restart Gateway" button is effectively a no-op.

The only workaround today is to `railway ssh` into the container and `rm /data/.hermes/gateway.pid` by hand, then hit restart.

## Evidence

`gateway_state.json` right before the crash loop began, showing the gateway was healthy with all platforms connected before the prior container shut down:

```json
{
  "pid": 15, "kind": "hermes-gateway",
  "gateway_state": "draining",
  "platforms": {
    "telegram":   {"state": "connected", ...},
    "slack":      {"state": "connected", ...},
    "api_server": {"state": "connected", ...}
  },
  "updated_at": "2026-04-22T01:58:21Z"
}
```

After the container cycled, `gateway.pid` still contained `{"pid": 15, ...}`. PID 15 no longer existed in the new container, but the PID-file race check inside `hermes gateway` bailed out regardless. Admin API `/setup/api/status` showed `{"state": "error", "pid": null, "restarts": 3}` with zero uptime across multiple restart attempts. Removing `gateway.pid` and hitting restart brought everything back instantly.

## Fix

Unconditional `rm -f` of the PID file inside `start.sh`, before `exec python /app/server.py`. We are pre-exec in a fresh container at that point, so no hermes process can possibly be running, which means the removal is always safe. It is a no-op on the very first boot (the file will not exist yet).

## Alternative placements considered

- **Inside `server.py` (before spawning `hermes gateway`):** would also work, but `start.sh` is the first code to touch `/data` and already does other one-time cleanup/init of the volume (mkdir, seed config.yaml, touch .env), so it is the natural home for this.
- **Upstream in hermes-agent itself:** the real root cause is that `hermes gateway` should either clean its own PID file on SIGTERM, or treat "same PID, different start_time" as stale. Worth fixing there too, but this template-level patch is the thing that immediately unblocks Railway deploys.

## Test plan

- [ ] Deploy this branch to Railway with a persistent `/data` volume that contains a stale `gateway.pid`
- [ ] Confirm gateway reaches `state: "running"` without manual intervention
- [ ] Confirm `/data/.hermes/gateway.pid` is recreated by the new `hermes gateway` (so the file is not permanently missing, only stale instances are cleared)
- [ ] Confirm subsequent redeploys also come up cleanly