### PR TITLE
fix deployment issue on railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,14 @@ RUN apt-get update && \
 # Deleting web/ afterwards makes hermes's internal _build_web_ui skip the
 # rebuild step (it early-returns when package.json is absent), so container
 # startup is fast and no runtime npm dependency is needed.
+# NOTE: We expand hermes-agent's `[all]` extra manually here, omitting `[mistral]`.
+# Upstream's `[mistral]` pins `mistralai>=2.3.0,<3`, but the `mistralai` project on
+# PyPI is currently quarantined (zero installable versions), which makes the full
+# `[all]` extra unresolvable. Drop `[mistral]` from our expansion until either
+# PyPI restores the package or upstream removes the pin.
 RUN git clone --depth 1 --branch ${HERMES_REF} https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent && \
     cd /opt/hermes-agent && \
-    uv pip install --system --no-cache -e ".[all]" && \
+    uv pip install --system --no-cache -e ".[modal,daytona,vercel,messaging,matrix,cron,cli,dev,tts-premium,slack,pty,honcho,mcp,homeassistant,sms,acp,voice,dingtalk,feishu,google,bedrock,web]" && \
     cd /opt/hermes-agent/web && \
     npm install --silent && \
     npm run build && \


### PR DESCRIPTION
Fixes this error in deployment:

```
Using Python 3.12.12 environment at: /usr/local
  × No solution found when resolving dependencies:
  ╰─▶ Because there are no versions of mistralai and hermes-agent[all]==0.13.0
      depends on mistralai>=2.3.0,<3, we can conclude that
      hermes-agent[all]==0.13.0 cannot be used.
      And because only hermes-agent[all]==0.13.0 is available and you
      require hermes-agent[all], we can conclude that your requirements are
      unsatisfiable.
```

whose root cause was that `mistralai` PyPI project quarantined (no installable versions). `hermes-agent[all]` pulls `[mistral]` extra which pins `mistralai>=2.3.0,<3`. `uv` can't resolve → build fails.

so the fix was: replace `[all]` with explicit extras minus mistral. 
