### PR TITLE
fix(server): deep-merge config.yaml on boot to preserve mcp_servers

### DIFF
--- a/server.py
+++ b/server.py
@@ -157,25 +157,59 @@ def read_env(path: Path) -> dict[str, str]:
 
 
 def write_config_yaml(data: dict[str, str]) -> None:
-    """Write a minimal config.yaml so hermes picks up the model and provider."""
+    """Write config.yaml — deep-merge template defaults with any existing user/cron-managed sections.
+
+    Previously this overwrote ``$HERMES_HOME/config.yaml`` with a hardcoded template
+    body on every boot, silently erasing user-managed top-level keys. The most
+    common casualty is ``mcp_servers`` — Hermes reads downstream MCP servers
+    *only* from this file (see ``hermes_cli/mcp_config.py:_get_mcp_servers``), so
+    the wipe broke ``hermes mcp add/test/list`` state across every container
+    restart and required hand-restoration after each redeploy.
+
+    The fix: load the existing file if any, apply the deployment-managed keys
+    (``model.default``, ``model.provider``, ``terminal``, ``agent``, ``data_dir``)
+    on top, and write the merged result. Unknown top-level keys (``mcp_servers``,
+    custom skill config, etc.) are preserved verbatim.
+    """
+    import yaml  # hermes-agent already pulls pyyaml; deferred import keeps cold start light
+
     model = data.get("LLM_MODEL", "")
     config_path = Path(HERMES_HOME) / "config.yaml"
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(f"""\
-model:
-  default: "{model}"
-  provider: "auto"
 
-terminal:
-  backend: "local"
-  timeout: 60
-  cwd: "/tmp"
+    existing: dict = {}
+    if config_path.exists():
+        try:
+            with config_path.open() as f:
+                loaded = yaml.safe_load(f)
+            if isinstance(loaded, dict):
+                existing = loaded
+        except (yaml.YAMLError, OSError):
+            # Treat unparseable as absent — we'll overwrite with template defaults.
+            existing = {}
 
-agent:
-  max_iterations: 50
+    merged = dict(existing)
 
-data_dir: "{HERMES_HOME}"
-""")
+    # Deployment-managed (always authoritative — these reflect the runtime env).
+    merged_model = dict(merged.get("model") if isinstance(merged.get("model"), dict) else {})
+    merged_model["default"] = model
+    merged_model["provider"] = "auto"
+    merged["model"] = merged_model
+
+    merged_terminal = dict(merged.get("terminal") if isinstance(merged.get("terminal"), dict) else {})
+    merged_terminal["backend"] = "local"
+    merged_terminal["timeout"] = 60
+    merged_terminal["cwd"] = "/tmp"
+    merged["terminal"] = merged_terminal
+
+    merged_agent = dict(merged.get("agent") if isinstance(merged.get("agent"), dict) else {})
+    merged_agent.setdefault("max_iterations", 50)
+    merged["agent"] = merged_agent
+
+    merged["data_dir"] = HERMES_HOME
+
+    with config_path.open("w") as f:
+        yaml.safe_dump(merged, f, sort_keys=False, default_flow_style=False)
 
 
 def write_env(path: Path, data: dict[str, str]) -> None:


### PR DESCRIPTION
## Problem

`server.py::write_config_yaml` (called from `Gateway.start()` at line 440 on every boot) overwrites `$HERMES_HOME/config.yaml` with a hardcoded template literal. Any top-level key not in the literal — most importantly `mcp_servers` — is silently erased.

The most common impact: this template is the supported way to host Hermes on Railway, including the **Hermes-Agent-as-thin-client-to-GBrain** topology that Garry Tan promoted on May 7-8 2026 ("GBrain also just added thin-client mode! So your Claude Code, or secondary agent (Hermes if you use Claw as primary or vice versa) doesn't have to run its own MCP server, it can just use GBrain over MCP as a thin client!"). For that to work, the user has to register an MCP server (`hermes mcp add <name> --url https://… --auth oauth`), which writes to `$HERMES_HOME/config.yaml` under `mcp_servers`. The very next `railway restart` wipes it.

Concrete repro on a live deployment using this template:

1. `hermes mcp add <name> --url https://<your-host>/mcp --auth oauth` — config.yaml gets the `mcp_servers.<name>` block.
2. `hermes mcp test <name>` → ✓ Connected, tools discovered.
3. `railway restart`.
4. After restart: `grep -c mcp_servers /data/.hermes/config.yaml` → `0`. Section gone. Hermes Gateway also caches the MCP registry at boot, so a cron-driven repair of `mcp_servers` 30 minutes later doesn't surface tools in the live agent — only another Gateway restart with config intact does.

Reproducible across `railway restart` (preserves rootfs, still hits the wipe), `railway redeploy` (rebuilds image, hits the wipe), and `railway redeploy --from-source` (same).

## Why this happens

`write_config_yaml` uses `config_path.write_text(...)` with a hardcoded f-string literal. There's no read of the existing file, so any non-template key is erased.

\`\`\`python
config_path.write_text(f\"\"\"\\
model:
  default: \"{model}\"
  provider: \"auto\"
…
\"\"\")
\`\`\`

## Fix

Load the existing file first, apply the deployment-managed keys (`model.default`, `model.provider`, `terminal`, `agent.max_iterations`, `data_dir`) on top, write the merged result. Unknown top-level keys pass through verbatim. `agent.max_iterations` uses `setdefault` so user overrides also survive.

`pyyaml` is already a transitive dependency via `pip install -e ".[all]"` two layers up in the Dockerfile (hermes-agent depends on it), so no `requirements.txt` change is needed.

## Verification

Local smoke test — config with a sample `mcp_servers.<name>` section + a Bearer header:

\`\`\`yaml
# Before write_config_yaml
mcp_servers:
  example:
    url: https://example.invalid/mcp
    headers:
      Authorization: Bearer redacted
    timeout: 120

# After write_config_yaml({'LLM_MODEL': 'z-ai/glm4.7'})
model:
  default: z-ai/glm4.7
  provider: auto
mcp_servers:
  example:
    url: https://example.invalid/mcp
    headers:
      Authorization: Bearer redacted
    timeout: 120
terminal:
  backend: local
  timeout: 60
  cwd: /tmp
agent:
  max_iterations: 50
data_dir: /tmp/…
\`\`\`

The `mcp_servers.example` block is intact (URL, headers, Bearer header), and the deployment-managed keys are applied on top.

## What this does NOT do

- Touch Hermes itself.
- Add new dependencies.
- Change the order of section initialisation in `Gateway.start()`.
- Affect any other env var or `.env` write path.

## Open companion issue

The `mistralai` PyPI quarantine workaround already in #20 is a related operational issue for the same template — that one's already fixed. This PR is on top of that fix (branched off `d239382`).