### PR TITLE
Codex/gateway sync

### DIFF
--- a/server.py
+++ b/server.py
@@ -38,6 +38,7 @@ import websockets.exceptions
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import (
+    FileResponse,
     HTMLResponse,
     JSONResponse,
     RedirectResponse,
@@ -54,6 +55,37 @@ HERMES_HOME = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
 ENV_FILE = Path(HERMES_HOME) / ".env"
 PAIRING_DIR = Path(HERMES_HOME) / "pairing"
 PAIRING_TTL = 3600
+
+FILE_BROWSER_DEFAULT_PATH = Path(os.environ.get("FILE_BROWSER_DEFAULT_PATH", "/data"))
+FILE_PREVIEW_MAX_BYTES = 256 * 1024
+FILE_BROWSER_BLOCKED_PREFIXES = ("/proc", "/dev", "/sys")
+FILE_BROWSER_DOCS = [
+    {
+        "path": "/data",
+        "label": "Railway volume",
+        "description": "Persistent volume mounted into this service. Files here survive redeploys and restarts.",
+    },
+    {
+        "path": "/data/.hermes",
+        "label": "Hermes runtime home",
+        "description": "Persistent Hermes config, sessions, logs, memories, skills, cron, hooks, and caches for this Railway template.",
+    },
+    {
+        "path": "/tmp",
+        "label": "Ephemeral scratch",
+        "description": "Temporary runtime space. Files here can disappear when the container restarts or redeploys.",
+    },
+    {
+        "path": "/app",
+        "label": "Admin wrapper app",
+        "description": "Dashboard server and templates copied into the container image at build time.",
+    },
+    {
+        "path": "/opt/hermes-agent",
+        "label": "Hermes install",
+        "description": "Hermes source/runtime installed into the image during the Docker build.",
+    },
+]
 
 # Native Hermes dashboard — runs on loopback, fronted by our reverse proxy.
 HERMES_DASHBOARD_HOST = "127.0.0.1"
@@ -952,6 +984,150 @@ async def api_config_reset(request: Request):
     return JSONResponse({"ok": True})
 
 
+# ── Read-only file browser ───────────────────────────────────────────────────
+def _file_browser_path(request: Request) -> Path:
+    raw = request.query_params.get("path") or str(FILE_BROWSER_DEFAULT_PATH)
+    path = Path(raw)
+    if not path.is_absolute():
+        raise ValueError("path must be absolute")
+    return path
+
+
+def _is_blocked_file_browser_path(path: Path) -> bool:
+    raw = str(path)
+    return any(raw == prefix or raw.startswith(f"{prefix}/") for prefix in FILE_BROWSER_BLOCKED_PREFIXES)
+
+
+def _entry_type(path: Path) -> str:
+    if path.is_symlink():
+        return "symlink"
+    if path.is_dir():
+        return "directory"
+    if path.is_file():
+        return "file"
+    return "other"
+
+
+def _file_entry(path: Path) -> dict:
+    entry_type = _entry_type(path)
+    try:
+        st = path.lstat()
+        size = st.st_size
+        modified = st.st_mtime
+    except OSError:
+        size = None
+        modified = None
+
+    return {
+        "name": path.name or str(path),
+        "path": str(path),
+        "type": entry_type,
+        "size": size,
+        "modified": modified,
+        "previewable": entry_type == "file" and not _is_blocked_file_browser_path(path),
+        "downloadable": entry_type == "file" and not _is_blocked_file_browser_path(path),
+    }
+
+
+def _sorted_file_entries(path: Path) -> list[dict]:
+    entries = []
+    for child in path.iterdir():
+        try:
+            entries.append(_file_entry(child))
+        except OSError:
+            continue
+    rank = {"directory": 0, "symlink": 1, "file": 2, "other": 3}
+    return sorted(entries, key=lambda e: (rank.get(e["type"], 9), e["name"].lower()))
+
+
+def _file_browser_payload(**extra) -> dict:
+    return {
+        "docs": FILE_BROWSER_DOCS,
+        "default_path": str(FILE_BROWSER_DEFAULT_PATH),
+        "note": (
+            "This Railway template sets HOME=/data and HERMES_HOME=/data/.hermes. "
+            "Official Hermes Docker examples often use /opt/data instead."
+        ),
+        **extra,
+    }
+
+
+async def api_files_list(request: Request):
+    if err := guard(request): return err
+    try:
+        path = _file_browser_path(request)
+    except ValueError as e:
+        return JSONResponse(_file_browser_payload(error=str(e)), status_code=400)
+    if not path.exists():
+        return JSONResponse(_file_browser_payload(error="Path not found"), status_code=404)
+    if not path.is_dir():
+        return JSONResponse(_file_browser_payload(error="Path is not a directory"), status_code=400)
+
+    try:
+        entries = _sorted_file_entries(path)
+    except PermissionError:
+        return JSONResponse(_file_browser_payload(error="Permission denied"), status_code=403)
+    except OSError as e:
+        return JSONResponse(_file_browser_payload(error=str(e)), status_code=500)
+
+    return JSONResponse(_file_browser_payload(
+        path=str(path),
+        parent=str(path.parent) if path.parent != path else None,
+        entries=entries,
+    ))
+
+
+async def api_files_preview(request: Request):
+    if err := guard(request): return err
+    try:
+        path = _file_browser_path(request)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    if _is_blocked_file_browser_path(path):
+        return JSONResponse({"error": "Preview is disabled for this virtual filesystem path"}, status_code=400)
+    if not path.exists():
+        return JSONResponse({"error": "Path not found"}, status_code=404)
+    if not path.is_file():
+        return JSONResponse({"error": "Path is not a file"}, status_code=400)
+
+    try:
+        with path.open("rb") as f:
+            data = f.read(FILE_PREVIEW_MAX_BYTES + 1)
+    except PermissionError:
+        return JSONResponse({"error": "Permission denied"}, status_code=403)
+    except OSError as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+    if b"\x00" in data:
+        return JSONResponse({"error": "Binary files are download-only"}, status_code=415)
+
+    truncated = len(data) > FILE_PREVIEW_MAX_BYTES
+    if truncated:
+        data = data[:FILE_PREVIEW_MAX_BYTES]
+    return JSONResponse({
+        "path": str(path),
+        "name": path.name,
+        "content": data.decode("utf-8", errors="replace"),
+        "truncated": truncated,
+        "max_bytes": FILE_PREVIEW_MAX_BYTES,
+    })
+
+
+async def api_files_download(request: Request):
+    if err := guard(request): return err
+    try:
+        path = _file_browser_path(request)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    if _is_blocked_file_browser_path(path):
+        return JSONResponse({"error": "Download is disabled for this virtual filesystem path"}, status_code=400)
+    if not path.exists():
+        return JSONResponse({"error": "Path not found"}, status_code=404)
+    if not path.is_file():
+        return JSONResponse({"error": "Path is not a file"}, status_code=400)
+    return FileResponse(path, filename=path.name)
+
+
 # ── Pairing ───────────────────────────────────────────────────────────────────
 def _pjson(path: Path) -> dict:
     try:
@@ -1402,6 +1578,9 @@ routes = [
     Route("/setup/api/pairing/deny",            api_pairing_deny,    methods=["POST"]),
     Route("/setup/api/pairing/approved",        api_pairing_approved),
     Route("/setup/api/pairing/revoke",          api_pairing_revoke,  methods=["POST"]),
+    Route("/setup/api/files/list",              api_files_list),
+    Route("/setup/api/files/preview",           api_files_preview),
+    Route("/setup/api/files/download",          api_files_download),
 
     # /setup/* typos return a real 404 — not a silent proxy fallthrough.
     Route("/setup/{path:path}",                 route_setup_404,     methods=ANY_METHOD),

--- a/server.py
+++ b/server.py
@@ -53,6 +53,7 @@ templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 
 HERMES_HOME = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
 ENV_FILE = Path(HERMES_HOME) / ".env"
+GATEWAY_PID_FILE = Path(HERMES_HOME) / "gateway.pid"
 PAIRING_DIR = Path(HERMES_HOME) / "pairing"
 PAIRING_TTL = 3600
 
@@ -737,8 +738,96 @@ class Gateway:
         self.started_at: float | None = None
         self.restarts = 0
 
+    def _managed_proc_running(self) -> bool:
+        return self.proc is not None and self.proc.returncode is None
+
+    def _pid_is_running(self, pid: int) -> bool:
+        if pid <= 0:
+            return False
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        except OSError:
+            return False
+
+    def _pid_file_running_pid(self, cleanup_stale: bool = True) -> int | None:
+        try:
+            raw = GATEWAY_PID_FILE.read_text().strip()
+            pid = int(raw)
+        except (FileNotFoundError, ValueError, OSError):
+            return None
+
+        if self._pid_is_running(pid):
+            return pid
+
+        if cleanup_stale:
+            try:
+                GATEWAY_PID_FILE.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                self.logs.append(f"[warn] Failed to remove stale gateway PID file: {exc}")
+        return None
+
+    def _running_pid(self) -> int | None:
+        if self._managed_proc_running():
+            return self.proc.pid
+        return self._pid_file_running_pid()
+
+    def _unlink_pid_file_if_matches(self, pid: int) -> None:
+        try:
+            raw = GATEWAY_PID_FILE.read_text().strip()
+            if int(raw) == pid:
+                GATEWAY_PID_FILE.unlink()
+        except (FileNotFoundError, ValueError, OSError):
+            pass
+
+    async def _terminate_pid(self, pid: int, timeout: float = 10.0) -> None:
+        if pid <= 0 or pid == os.getpid():
+            return
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            self._unlink_pid_file_if_matches(pid)
+            return
+        except OSError as exc:
+            self.logs.append(f"[warn] Failed to stop gateway PID {pid}: {exc}")
+            return
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if not self._pid_is_running(pid):
+                self._unlink_pid_file_if_matches(pid)
+                return
+            await asyncio.sleep(0.2)
+
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        except OSError as exc:
+            self.logs.append(f"[warn] Failed to kill gateway PID {pid}: {exc}")
+            return
+
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            if not self._pid_is_running(pid):
+                self._unlink_pid_file_if_matches(pid)
+                return
+            await asyncio.sleep(0.2)
+
     async def start(self):
-        if self.proc and self.proc.returncode is None:
+        if self._managed_proc_running():
+            return
+        if existing_pid := self._pid_file_running_pid():
+            self.proc = None
+            self.state = "running"
+            self.started_at = self.started_at or time.time()
+            self.logs.append(f"[gateway] Using existing gateway process PID {existing_pid}")
             return
         self.state = "starting"
         try:
@@ -760,22 +849,31 @@ class Gateway:
             )
             self.state = "running"
             self.started_at = time.time()
-            asyncio.create_task(self._drain())
+            asyncio.create_task(self._drain(self.proc))
         except Exception as e:
             self.state = "error"
             self.logs.append(f"[error] Failed to start: {e}")
 
     async def stop(self):
-        if not self.proc or self.proc.returncode is not None:
+        if not self._managed_proc_running():
+            if external_pid := self._pid_file_running_pid():
+                self.state = "stopping"
+                await self._terminate_pid(external_pid)
+                self.state = "stopped"
+                self.started_at = None
+                return
             self.state = "stopped"
+            self.started_at = None
             return
         self.state = "stopping"
-        self.proc.terminate()
+        proc = self.proc
+        proc.terminate()
         try:
-            await asyncio.wait_for(self.proc.wait(), timeout=10)
+            await asyncio.wait_for(proc.wait(), timeout=10)
         except asyncio.TimeoutError:
-            self.proc.kill()
-            await self.proc.wait()
+            proc.kill()
+            await proc.wait()
+        self._unlink_pid_file_if_matches(proc.pid)
         self.state = "stopped"
         self.started_at = None
 
@@ -784,20 +882,26 @@ class Gateway:
         self.restarts += 1
         await self.start()
 
-    async def _drain(self):
-        assert self.proc and self.proc.stdout
-        async for raw in self.proc.stdout:
+    async def _drain(self, proc: asyncio.subprocess.Process):
+        assert proc.stdout
+        async for raw in proc.stdout:
             line = ANSI_ESCAPE.sub("", raw.decode(errors="replace").rstrip())
             self.logs.append(line)
-        if self.state == "running":
+        if self.proc is proc and self.state == "running":
             self.state = "error"
-            self.logs.append(f"[error] Gateway exited (code {self.proc.returncode})")
+            self.logs.append(f"[error] Gateway exited (code {proc.returncode})")
 
     def status(self) -> dict:
-        uptime = int(time.time() - self.started_at) if self.started_at and self.state == "running" else None
+        pid = self._running_pid()
+        state = self.state
+        if pid and not self._managed_proc_running():
+            state = "running"
+        elif not pid and state == "running":
+            state = "stopped"
+        uptime = int(time.time() - self.started_at) if self.started_at and state == "running" else None
         return {
-            "state":    self.state,
-            "pid":      self.proc.pid if self.proc and self.proc.returncode is None else None,
+            "state":    state,
+            "pid":      pid,
             "uptime":   uptime,
             "restarts": self.restarts,
         }
@@ -901,7 +1005,7 @@ async def page_index(request: Request):
 
 
 async def route_health(request: Request):
-    return JSONResponse({"status": "ok", "gateway": gw.state})
+    return JSONResponse({"status": "ok", "gateway": gw.status()["state"]})
 
 
 async def api_config_get(request: Request):
@@ -972,6 +1076,53 @@ async def api_gw_restart(request: Request):
     if err := guard(request): return err
     asyncio.create_task(gw.restart())
     return JSONResponse({"ok": True})
+
+
+async def api_native_gw_start(request: Request):
+    """Handle native dashboard gateway starts through this wrapper's manager.
+
+    The proxied Hermes dashboard has its own `/api/gateway/*` controls. Letting
+    those pass through creates a second gateway lifecycle owner, which can leave
+    the setup UI trying to start a gateway that the native UI already spawned.
+    """
+    if err := guard(request): return err
+    asyncio.create_task(gw.start())
+    return JSONResponse({"ok": True, "name": "gateway-start"})
+
+
+async def api_native_gw_stop(request: Request):
+    if err := guard(request): return err
+    asyncio.create_task(gw.stop())
+    return JSONResponse({"ok": True, "name": "gateway-stop"})
+
+
+async def api_native_gw_restart(request: Request):
+    if err := guard(request): return err
+    asyncio.create_task(gw.restart())
+    return JSONResponse({"ok": True, "name": "gateway-restart"})
+
+
+async def api_native_gateway_action_status(request: Request):
+    if err := guard(request): return err
+    try:
+        line_count = min(max(int(request.query_params.get("lines", "200")), 1), 2000)
+    except ValueError:
+        line_count = 200
+    status = gw.status()
+    running = status["state"] in ("starting", "stopping")
+    if status["state"] in ("running", "stopped"):
+        exit_code = 0
+    elif running:
+        exit_code = None
+    else:
+        exit_code = 1
+    return JSONResponse({
+        "name": "gateway-restart",
+        "running": running,
+        "exit_code": exit_code,
+        "pid": status["pid"],
+        "lines": list(gw.logs)[-line_count:],
+    })
 
 
 async def api_config_reset(request: Request):
@@ -1594,6 +1745,13 @@ routes = [
     WebSocketRoute("/api/pty",                  ws_proxy),
     WebSocketRoute("/api/ws",                   ws_proxy),
     WebSocketRoute("/api/events",               ws_proxy),
+
+    # Native Hermes dashboard gateway controls. Keep gateway mutations owned by
+    # this wrapper so /setup and / stay synchronized on one process lifecycle.
+    Route("/api/gateway/start",                 api_native_gw_start, methods=["POST"]),
+    Route("/api/gateway/stop",                  api_native_gw_stop,  methods=["POST"]),
+    Route("/api/gateway/restart",               api_native_gw_restart, methods=["POST"]),
+    Route("/api/actions/gateway-restart/status", api_native_gateway_action_status),
 
     # Root: redirect to /setup if unconfigured, otherwise proxy the dashboard.
     Route("/",                                  route_root,          methods=ANY_METHOD),

--- a/server.py
+++ b/server.py
@@ -795,20 +795,50 @@ async def api_pairing_revoke(request: Request):
 
 
 # ── Reverse proxy → Hermes dashboard ──────────────────────────────────────────
-_WIDGET_LINK_STYLE = (
-    "background:rgba(20,24,31,0.92);backdrop-filter:blur(8px);"
-    "border:1px solid #252d3d;border-radius:6px;padding:6px 12px;"
-    "color:#c9d1d9;text-decoration:none;display:inline-flex;"
-    "align-items:center;gap:6px;"
-)
-BACK_TO_SETUP_WIDGET = (
-    '<div id="hermes-back-widget" style="position:fixed;bottom:14px;right:14px;'
-    'z-index:99999;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;'
-    'font-size:11px;display:flex;gap:8px;">'
-    f'<a href="/setup" style="{_WIDGET_LINK_STYLE}">← Setup</a>'
-    f'<a href="/logout" style="{_WIDGET_LINK_STYLE}">Sign out</a>'
-    '</div>'
-)
+# Floating "back-to-setup" widget injected before </body> on every proxied HTML
+# page. Styled on the Dayshift Systems design system (Ivory & Ink): collapsed
+# 32×32 ivory-bordered tile at rest, expands on :hover / :focus-within to reveal
+# Setup + Sign out links. All selectors are scoped under #hermes-back-widget so
+# styles can't leak into the proxied Hermes dashboard.
+BACK_TO_SETUP_WIDGET = """\
+<style>
+#hermes-back-widget{position:fixed;bottom:14px;right:14px;z-index:99999;\
+display:inline-flex;align-items:stretch;border-radius:8px;\
+background:rgba(24,24,20,0.6);border:1px solid rgba(255,255,227,0.10);\
+backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);overflow:hidden;\
+font-family:"Inter Tight",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;\
+transition:border-color 400ms cubic-bezier(0.25,0.46,0.45,0.94),\
+background-color 400ms cubic-bezier(0.25,0.46,0.45,0.94)}
+#hermes-back-widget:hover,#hermes-back-widget:focus-within{\
+border-color:rgba(255,255,227,0.30);background:#181814}
+#hermes-back-widget .hbw-link{display:inline-flex;align-items:center;\
+height:32px;max-width:0;padding:0;margin:0;color:rgba(255,255,227,0.90);\
+font-size:11px;font-weight:500;letter-spacing:0.06em;text-transform:uppercase;\
+text-decoration:none;white-space:nowrap;overflow:hidden;opacity:0;\
+transition:max-width 400ms cubic-bezier(0.25,0.46,0.45,0.94),\
+padding 400ms cubic-bezier(0.25,0.46,0.45,0.94),\
+opacity 200ms cubic-bezier(0.25,0.46,0.45,0.94),\
+background-color 400ms cubic-bezier(0.25,0.46,0.45,0.94),\
+color 400ms cubic-bezier(0.25,0.46,0.45,0.94)}
+#hermes-back-widget:hover .hbw-link,#hermes-back-widget:focus-within .hbw-link{\
+max-width:140px;padding:0 12px;opacity:1}
+#hermes-back-widget .hbw-link:hover{color:#FFFFE3;background:rgba(255,255,227,0.05)}
+#hermes-back-widget .hbw-link:focus-visible{outline:2px solid #7A9E90;outline-offset:-2px}
+#hermes-back-widget .hbw-trigger{display:inline-flex;align-items:center;\
+justify-content:center;width:32px;height:32px;color:rgba(255,255,227,0.60);\
+flex-shrink:0;transition:color 400ms cubic-bezier(0.25,0.46,0.45,0.94)}
+#hermes-back-widget:hover .hbw-trigger,#hermes-back-widget:focus-within .hbw-trigger{\
+color:rgba(255,255,227,0.90)}
+</style>
+<div id="hermes-back-widget" role="navigation" aria-label="Setup actions">\
+<a class="hbw-link" href="/setup">← Setup</a>\
+<a class="hbw-link" href="/logout">Sign out</a>\
+<span class="hbw-trigger" aria-hidden="true">\
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" \
+stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">\
+<line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/>\
+<line x1="4" y1="18" x2="20" y2="18"/></svg></span></div>\
+"""
 
 DASHBOARD_UNAVAILABLE_HTML = """<!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><title>Dashboard starting…</title>

--- a/server.py
+++ b/server.py
@@ -352,50 +352,298 @@ def guard(request: Request) -> Response | None:
 LOGIN_PAGE_HTML = """<!DOCTYPE html>
 <html lang="en"><head>
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Hermes Agent — Sign in</title>
+<title>Hermes Agent - Sign in</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
+:root{
+  --ds-bg: #10100E;
+  --ds-surface: #181814;
+  --ds-elevated: #1E1E1C;
+  --ds-primary: #FFFFE3;
+  --ds-accent: #7A9E90;
+  --ds-ivory-88: rgba(255,255,227,0.88);
+  --ds-ivory-80: rgba(255,255,227,0.8);
+  --ds-ivory-60: rgba(255,255,227,0.6);
+  --ds-ivory-40: rgba(255,255,227,0.4);
+  --ds-ivory-30: rgba(255,255,227,0.3);
+  --ds-ivory-10: rgba(255,255,227,0.1);
+  --ds-ivory-05: rgba(255,255,227,0.05);
+  --sys-red: #B88078;
+  --font-body: 'Inter Tight', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  --ease-luxe: cubic-bezier(0.25,0.46,0.45,0.94);
+}
 *{box-sizing:border-box;margin:0;padding:0}
-body{background:#0d0f14;color:#c9d1d9;font-family:'IBM Plex Sans',sans-serif;
-  min-height:100vh;display:flex;align-items:center;justify-content:center;padding:20px}
-.card{background:#14181f;border:1px solid #252d3d;border-radius:12px;padding:36px 32px;width:100%;max-width:380px;
-  box-shadow:0 20px 40px rgba(0,0,0,0.4)}
-.brand{text-align:center;margin-bottom:28px}
-.brand-logo{display:inline-flex;align-items:center;gap:10px;font-family:'IBM Plex Mono',monospace;font-weight:600;font-size:18px;color:#6272ff}
-.brand-logo span{color:#6b7688;font-weight:400}
-.brand-sub{font-family:'IBM Plex Mono',monospace;font-size:11px;color:#6b7688;margin-top:8px;letter-spacing:1.5px;text-transform:uppercase}
-label{display:block;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#6b7688;
-  letter-spacing:0.05em;text-transform:uppercase;margin-bottom:6px;margin-top:16px}
-input{width:100%;background:#0d0f14;border:1px solid #252d3d;border-radius:6px;color:#c9d1d9;
-  font-family:'IBM Plex Mono',monospace;font-size:13px;padding:9px 11px;outline:none;transition:border-color .15s}
-input:focus{border-color:#6272ff}
-button{width:100%;margin-top:24px;background:#6272ff;border:1px solid #6272ff;border-radius:6px;color:#fff;
-  font-family:'IBM Plex Mono',monospace;font-size:13px;font-weight:500;padding:10px;cursor:pointer;
-  transition:background .15s,border-color .15s}
-button:hover{background:#7b8fff;border-color:#7b8fff}
-.err{background:rgba(248,81,73,0.08);border:1px solid rgba(248,81,73,0.3);border-radius:6px;
-  color:#f85149;font-family:'IBM Plex Mono',monospace;font-size:12px;padding:8px 12px;margin-bottom:14px;text-align:center}
-.footnote{margin-top:18px;font-family:'IBM Plex Mono',monospace;font-size:10px;color:#6b7688;text-align:center;line-height:1.6}
+html{min-height:100%}
+body{
+  min-height:100vh;
+  background:var(--ds-bg);
+  color:var(--ds-primary);
+  font-family:var(--font-body);
+  display:grid;
+  place-items:center;
+  padding:32px 20px;
+}
+body::before{
+  content:"";
+  position:fixed;
+  inset:0;
+  pointer-events:none;
+  background:
+    linear-gradient(rgba(255,255,227,0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,227,0.035) 1px, transparent 1px);
+  background-size:64px 64px;
+  mask-image:linear-gradient(to bottom, rgba(0,0,0,0.45), transparent 72%);
+}
+.shell{
+  width:min(100%, 1020px);
+  display:grid;
+  grid-template-columns:minmax(0, 1fr) 420px;
+  min-height:560px;
+  border:1px solid var(--ds-ivory-10);
+  border-radius:8px;
+  background:rgba(24,24,20,0.6);
+  backdrop-filter:blur(4px);
+  overflow:hidden;
+  position:relative;
+}
+.intro{
+  padding:56px;
+  display:flex;
+  flex-direction:column;
+  justify-content:space-between;
+  border-right:1px solid var(--ds-ivory-10);
+}
+.mark{
+  display:inline-flex;
+  flex-direction:column;
+  line-height:.92;
+  color:var(--ds-primary);
+}
+.mark-main{
+  font-size:22px;
+  font-weight:500;
+  letter-spacing:-0.02em;
+}
+.mark-sub{
+  margin-top:5px;
+  font-size:11px;
+  font-weight:300;
+  letter-spacing:.14em;
+  text-transform:uppercase;
+}
+.intro-copy{max-width:500px}
+.rule{
+  display:block;
+  width:32px;
+  height:1px;
+  background:var(--ds-accent);
+  margin-bottom:16px;
+}
+.eyebrow{
+  display:block;
+  font-size:13px;
+  font-weight:500;
+  letter-spacing:.06em;
+  text-transform:uppercase;
+  color:var(--ds-ivory-88);
+  margin-bottom:18px;
+}
+h1{
+  font-size:clamp(44px, 7vw, 76px);
+  font-weight:500;
+  letter-spacing:-0.025em;
+  line-height:.95;
+  color:var(--ds-primary);
+  max-width:560px;
+}
+.intro-text{
+  margin-top:24px;
+  max-width:440px;
+  color:var(--ds-ivory-80);
+  font-size:17px;
+  line-height:1.55;
+}
+.status-row{
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  color:var(--ds-ivory-60);
+  font-family:var(--font-mono);
+  font-size:11px;
+}
+.status-pill{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  border:1px solid var(--ds-ivory-10);
+  border-radius:6px;
+  padding:8px 10px;
+  background:var(--ds-ivory-05);
+}
+.status-dot{
+  width:6px;
+  height:6px;
+  border-radius:50%;
+  background:var(--ds-accent);
+  box-shadow:0 0 16px rgba(122,158,144,0.45);
+}
+.auth{
+  background:var(--ds-bg);
+  padding:56px 44px;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+}
+.auth-kicker{
+  font-family:var(--font-mono);
+  color:var(--ds-ivory-60);
+  font-size:11px;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  margin-bottom:12px;
+}
+.auth-title{
+  color:var(--ds-primary);
+  font-size:28px;
+  font-weight:500;
+  letter-spacing:-0.015em;
+  line-height:1.1;
+}
+.auth-note{
+  margin-top:12px;
+  color:var(--ds-ivory-80);
+  font-size:15px;
+  line-height:1.5;
+}
+form{margin-top:32px}
+label{
+  display:block;
+  margin:18px 0 7px;
+  color:var(--ds-ivory-80);
+  font-size:12px;
+  font-weight:500;
+  letter-spacing:.04em;
+  text-transform:uppercase;
+}
+input{
+  width:100%;
+  border:1px solid var(--ds-ivory-10);
+  border-radius:8px;
+  background:rgba(24,24,20,0.6);
+  color:var(--ds-primary);
+  font-family:var(--font-body);
+  font-size:15px;
+  padding:13px 14px;
+  outline:none;
+  transition:border-color 200ms var(--ease-luxe), outline-color 200ms var(--ease-luxe), background 200ms var(--ease-luxe);
+}
+input::placeholder{color:var(--ds-ivory-40)}
+input:focus{border-color:var(--ds-primary)}
+input:focus-visible{
+  outline:2px solid var(--ds-accent);
+  outline-offset:2px;
+}
+button{
+  width:100%;
+  margin-top:28px;
+  border:0;
+  border-radius:8px;
+  background:var(--ds-primary);
+  color:var(--ds-bg);
+  font-family:var(--font-body);
+  font-size:14px;
+  font-weight:500;
+  letter-spacing:.04em;
+  text-transform:uppercase;
+  padding:13px 20px;
+  cursor:pointer;
+  transition:background 400ms var(--ease-luxe), transform 400ms var(--ease-luxe), box-shadow 400ms var(--ease-luxe);
+}
+button:hover{
+  background:rgba(255,255,227,0.9);
+  transform:translateY(-1px) scale(1.02);
+  box-shadow:0 10px 25px rgba(0,0,0,0.3);
+}
+button:active{transform:scale(.98)}
+button:focus-visible{
+  outline:2px solid var(--ds-accent);
+  outline-offset:3px;
+}
+.err{
+  margin-top:22px;
+  border:1px solid rgba(184,128,120,0.35);
+  border-radius:8px;
+  background:rgba(184,128,120,0.12);
+  color:#D8AAA4;
+  font-family:var(--font-mono);
+  font-size:12px;
+  line-height:1.4;
+  padding:10px 12px;
+}
+.footnote{
+  margin-top:22px;
+  color:var(--ds-ivory-60);
+  font-family:var(--font-mono);
+  font-size:11px;
+  line-height:1.7;
+}
+code{
+  color:var(--ds-ivory-88);
+  font-family:var(--font-mono);
+}
+@media (max-width: 820px){
+  body{padding:20px}
+  .shell{grid-template-columns:1fr;min-height:0}
+  .intro{padding:36px 28px;border-right:0;border-bottom:1px solid var(--ds-ivory-10);gap:56px}
+  .auth{padding:34px 28px}
+  h1{font-size:44px}
+}
+@media (max-width: 520px){
+  body{display:block;padding:0;background:var(--ds-bg)}
+  body::before{display:none}
+  .shell{border:0;border-radius:0;min-height:100vh}
+  .intro{padding:28px 20px}
+  .auth{padding:32px 20px}
+  h1{font-size:38px}
+}
 </style></head>
 <body>
-<div class="card">
-  <div class="brand">
-    <div class="brand-logo">hermes<span>/admin</span></div>
-    <div class="brand-sub">Sign in to continue</div>
-  </div>
-  __ERROR__
-  <form method="POST" action="/login">
-    <input type="hidden" name="returnTo" value="__RETURN_TO__">
-    <label for="username">Username</label>
-    <input id="username" name="username" type="text" autocomplete="username" autofocus required>
-    <label for="password">Password</label>
-    <input id="password" name="password" type="password" autocomplete="current-password" required>
-    <button type="submit">Sign in</button>
-  </form>
-  <p class="footnote">Credentials are the <code>ADMIN_USERNAME</code> and <code>ADMIN_PASSWORD</code><br>Railway service variables.</p>
-</div>
+<main class="shell" aria-label="Hermes admin sign in">
+  <section class="intro" aria-label="Hermes agent">
+    <div class="mark" aria-label="Hermes admin">
+      <span class="mark-main">hermes</span>
+      <span class="mark-sub">admin</span>
+    </div>
+    <div class="intro-copy">
+      <span class="rule" aria-hidden="true"></span>
+      <span class="eyebrow">Private agent operations</span>
+      <h1>Deploy and manage Hermes.</h1>
+      <p class="intro-text">A focused control surface for configuration, gateway state, pairing requests, and the native Hermes dashboard.</p>
+    </div>
+    <div class="status-row" aria-label="Session details">
+      <span class="status-pill"><span class="status-dot" aria-hidden="true"></span> Cookie session</span>
+      <span class="status-pill">Railway ready</span>
+    </div>
+  </section>
+  <section class="auth" aria-label="Sign in form">
+    <div class="auth-kicker">WELCOME BACK</div>
+    <h2 class="auth-title">Sign in to continue.</h2>
+    <p class="auth-note">Use the admin credentials configured for this deployment.</p>
+    __ERROR__
+    <form method="POST" action="/login">
+      <input type="hidden" name="returnTo" value="__RETURN_TO__">
+      <label for="username">Username</label>
+      <input id="username" name="username" type="text" autocomplete="username" autofocus required>
+      <label for="password">Password</label>
+      <input id="password" name="password" type="password" autocomplete="current-password" required>
+      <button type="submit">Sign in</button>
+    </form>
+    <p class="footnote">Credentials are the <code>ADMIN_USERNAME</code> and <code>ADMIN_PASSWORD</code><br>Railway service variables.</p>
+  </section>
+</main>
 </body></html>"""
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,77 +6,159 @@
 <title>Hermes Agent</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 <style>
+  /* =========================================================================
+     Dayshift Systems — Ivory & Ink (Dark Mode, Luxury)
+     Tokens lifted directly from dayshift-systems-design-system/colors_and_type.css
+     ========================================================================= */
   :root {
-    --bg:        #0d0f14;
-    --surface:   #14181f;
-    --surface2:  #1c2230;
-    --border:    #252d3d;
-    --text:      #c9d1d9;
-    --text-dim:  #6b7688;
-    --accent:    #6272ff;
-    --accent2:   #7b8fff;
-    --green:     #3fb950;
-    --yellow:    #d29922;
-    --red:       #f85149;
-    --font-mono: 'IBM Plex Mono', monospace;
-    --font-sans: 'IBM Plex Sans', sans-serif;
-    --sidebar-w: 220px;
-    --header-h:  52px;
+    /* Core palette */
+    --ds-bg:        #10100E;
+    --ds-surface:   #161614;
+    --ds-elevated:  #1E1E1C;
+    --ds-muted:     #606058;
+    --ds-secondary: #9A9888;
+    --ds-accent:    #7A9E90;  /* muted jade — sparingly */
+    --ds-primary:   #FFFFE3;  /* ivory */
+
+    /* Translucent ivory ladder */
+    --iv-95: rgba(255,255,227,0.95);
+    --iv-90: rgba(255,255,227,0.90);
+    --iv-80: rgba(255,255,227,0.80);
+    --iv-60: rgba(255,255,227,0.60);
+    --iv-40: rgba(255,255,227,0.40);
+    --iv-30: rgba(255,255,227,0.30);
+    --iv-18: rgba(255,255,227,0.18);
+    --iv-10: rgba(255,255,227,0.10);
+    --iv-05: rgba(255,255,227,0.05);
+
+    --surface-60: rgba(24,24,20,0.6);
+    --surface-40: rgba(24,24,20,0.4);
+
+    /* System / status (luxury-desaturated) */
+    --sys-blue:   #8898AA;
+    --sys-red:    #B88078;
+    --sys-green:  #80A488;
+    --sys-yellow: #B8A868;
+
+    --font-body: "Inter Tight", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+    --ease-luxe: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    --dur-fast:  200ms;
+    --dur-base:  400ms;
+    --dur-slow:  600ms;
+
+    --header-h:  64px;
+    --sidebar-w: 240px;
   }
 
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
   body {
-    background: var(--bg);
-    color: var(--text);
-    font-family: var(--font-sans);
+    background: var(--ds-bg);
+    color: var(--ds-primary);
+    font-family: var(--font-body);
     font-size: 14px;
+    line-height: 1.55;
     height: 100vh;
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 
   [x-cloak] { display: none !important; }
 
+  /* Inline SVG icons — strict 1.5px stroke, currentColor, line-only.
+     Geometry follows Lucide; we ship only the icons we use. */
+  .icon {
+    width: 16px; height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    flex-shrink: 0;
+  }
+  .icon.lg { width: 20px; height: 20px; }
+  .icon.xs { width: 14px; height: 14px; }
+  .sprite { position: absolute; width: 0; height: 0; overflow: hidden; }
+
+  a { color: inherit; text-decoration: none; }
+
+  /* Ivory link — sweeping jade underline on hover (.ds-link from design system) */
+  .ds-link {
+    color: inherit;
+    background-image: linear-gradient(var(--ds-accent), var(--ds-accent));
+    background-size: 0 1px;
+    background-repeat: no-repeat;
+    background-position: 0 100%;
+    transition: background-size var(--dur-base) var(--ease-luxe);
+  }
+  .ds-link:hover { background-size: 100% 1px; }
+
   /* ── Header ───────────────────────────────────────── */
   #header {
     height: var(--header-h);
-    background: var(--surface);
-    border-bottom: 1px solid var(--border);
+    background: var(--ds-bg);
+    border-bottom: 1px solid var(--iv-10);
     display: flex;
     align-items: center;
-    padding: 0 20px;
-    gap: 12px;
+    padding: 0 28px;
+    gap: 20px;
     flex-shrink: 0;
+    backdrop-filter: blur(4px);
   }
 
-  .logo {
-    font-family: var(--font-mono);
-    font-weight: 600;
-    font-size: 16px;
-    color: var(--accent);
-    letter-spacing: -0.5px;
+  .wordmark {
+    display: flex;
+    flex-direction: column;
+    line-height: 1;
     user-select: none;
   }
-  .logo span { color: var(--text-dim); font-weight: 400; }
+  .wordmark .top {
+    font-family: var(--font-body);
+    font-weight: 500;
+    font-size: 18px;
+    letter-spacing: -0.02em;
+    color: var(--ds-primary);
+  }
+  .wordmark .sub {
+    font-family: var(--font-body);
+    font-weight: 300;
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--iv-60);
+    margin-top: 3px;
+  }
+
+  .status-cluster {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding-left: 20px;
+    border-left: 1px solid var(--iv-10);
+    margin-left: 4px;
+  }
 
   .status-dot {
     width: 8px; height: 8px;
     border-radius: 50%;
-    background: var(--text-dim);
-    transition: background 0.3s;
+    background: var(--ds-muted);
+    transition: background var(--dur-base) var(--ease-luxe);
     flex-shrink: 0;
   }
-  .status-dot.running  { background: var(--green); box-shadow: 0 0 6px var(--green); }
+  .status-dot.running  { background: var(--ds-accent); box-shadow: 0 0 0 3px rgba(122,158,144,0.20); }
   .status-dot.starting,
-  .status-dot.stopping { background: var(--yellow); animation: pulse 1s infinite; }
+  .status-dot.stopping { background: var(--sys-yellow); animation: pulse 1.6s var(--ease-luxe) infinite; }
   .status-dot.error,
-  .status-dot.crashed  { background: var(--red); }
-  .status-dot.stopped  { background: var(--text-dim); }
+  .status-dot.crashed  { background: var(--sys-red); }
+  .status-dot.stopped  { background: var(--ds-muted); }
 
   @keyframes pulse {
     0%, 100% { opacity: 1; }
@@ -85,36 +167,108 @@
 
   #status-label {
     font-family: var(--font-mono);
-    font-size: 12px;
-    color: var(--text-dim);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--iv-60);
   }
 
   .header-spacer { flex: 1; }
 
-  .header-btn {
-    background: var(--surface2);
-    border: 1px solid var(--border);
-    color: var(--text);
-    padding: 5px 12px;
-    border-radius: 6px;
-    font-family: var(--font-mono);
+  /* ── Buttons ──────────────────────────────────────────
+     Primary = ivory bg, ink text (inverted on dark).
+     Outline = transparent, ivory-30 border. Hover lifts border to ivory.
+     System variants only used in dashboard contexts (start/stop/danger). */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 9px 18px;
+    border-radius: 8px;
+    border: 1px solid var(--iv-30);
+    background: transparent;
+    color: var(--ds-primary);
+    font-family: var(--font-body);
+    font-weight: 500;
     font-size: 12px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
     cursor: pointer;
-    transition: border-color 0.15s, color 0.15s;
+    transition: all var(--dur-base) var(--ease-luxe);
+    user-select: none;
+    white-space: nowrap;
   }
-  .header-btn:hover { border-color: var(--accent); color: var(--accent); }
+  .btn:hover {
+    border-color: var(--ds-primary);
+    transform: translateY(-1px);
+  }
+  .btn:active { transform: scale(0.97); }
+  .btn:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+    transform: none;
+    border-color: var(--iv-30);
+  }
+  .btn:focus-visible {
+    outline: 2px solid var(--ds-accent);
+    outline-offset: 2px;
+  }
 
-  .header-issue-link {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    color: var(--text-dim);
-    text-decoration: none;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    padding: 5px 10px;
-    transition: border-color 0.15s, color 0.15s;
+  .btn.primary {
+    background: var(--ds-primary);
+    border-color: var(--ds-primary);
+    color: var(--ds-bg);
   }
-  .header-issue-link:hover { border-color: #e5534b; color: #e5534b; }
+  .btn.primary:hover {
+    background: var(--iv-90);
+    border-color: var(--iv-90);
+    box-shadow: 0 10px 25px rgba(0,0,0,0.3);
+  }
+
+  .btn.danger {
+    border-color: rgba(184,128,120,0.4);
+    color: var(--sys-red);
+  }
+  .btn.danger:hover {
+    background: var(--sys-red);
+    border-color: var(--sys-red);
+    color: var(--ds-bg);
+  }
+
+  .btn.success {
+    border-color: rgba(128,164,136,0.4);
+    color: var(--sys-green);
+  }
+  .btn.success:hover {
+    background: var(--sys-green);
+    border-color: var(--sys-green);
+    color: var(--ds-bg);
+  }
+
+  .btn.sm { padding: 6px 12px; font-size: 11px; letter-spacing: 0.05em; }
+
+  /* Header inline buttons read smaller / quieter */
+  .header-btn {
+    padding: 7px 14px;
+    border-radius: 8px;
+    border: 1px solid var(--iv-30);
+    background: transparent;
+    color: var(--ds-primary);
+    font-family: var(--font-body);
+    font-weight: 500;
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: all var(--dur-base) var(--ease-luxe);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .header-btn:hover { border-color: var(--ds-primary); transform: translateY(-1px); }
+  .header-btn.muted { border-color: var(--iv-10); color: var(--iv-60); }
+  .header-btn.muted:hover { border-color: var(--iv-30); color: var(--ds-primary); }
 
   /* ── Layout ───────────────────────────────────────── */
   #layout {
@@ -126,92 +280,90 @@
   /* ── Sidebar ──────────────────────────────────────── */
   #sidebar {
     width: var(--sidebar-w);
-    background: var(--surface);
-    border-right: 1px solid var(--border);
+    background: var(--ds-bg);
+    border-right: 1px solid var(--iv-10);
     display: flex;
     flex-direction: column;
     flex-shrink: 0;
-    padding: 12px 0;
+    padding: 24px 0 16px;
     overflow-y: auto;
   }
 
   .nav-group-label {
     font-family: var(--font-mono);
     font-size: 10px;
-    letter-spacing: 1.5px;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: var(--text-dim);
-    padding: 8px 16px 4px;
+    color: var(--iv-40);
+    padding: 14px 24px 8px;
   }
 
   .nav-item {
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 8px 16px;
+    gap: 12px;
+    padding: 9px 24px;
     cursor: pointer;
-    color: var(--text-dim);
+    color: var(--iv-60);
     border-left: 2px solid transparent;
-    transition: all 0.15s;
-    font-size: 13.5px;
+    transition: all var(--dur-base) var(--ease-luxe);
+    font-size: 13px;
+    font-weight: 400;
     user-select: none;
     position: relative;
   }
-  .nav-item:hover  { color: var(--text); background: var(--surface2); }
-  .nav-item.active { color: var(--text); border-left-color: var(--accent); background: var(--surface2); }
-  .nav-item.locked { opacity: 0.35; cursor: not-allowed; pointer-events: none; }
-  .nav-item.danger { color: var(--red); }
-  .nav-item.danger:hover { color: var(--red); background: rgba(248,81,73,0.08); border-left-color: var(--red); }
+  .nav-item:hover  { color: var(--ds-primary); background: var(--iv-05); }
+  .nav-item.active {
+    color: var(--ds-primary);
+    border-left-color: var(--ds-primary);
+    background: var(--iv-05);
+  }
+  .nav-item.locked { opacity: 0.3; cursor: not-allowed; pointer-events: none; }
+  .nav-item.danger { color: var(--iv-60); }
+  .nav-item.danger:hover { color: var(--sys-red); background: rgba(184,128,120,0.06); border-left-color: var(--sys-red); }
 
-  /* Dashboard is a *link out* to the native hermes UI, not a tab in this
-     wrapper. Style it as a pill/CTA so it reads differently from the
-     "active tab" indicator (which uses a left border + surface2 bg). */
+  /* Hermes Dashboard nav is a link OUT — styled as primary CTA pill so it
+     reads differently from the in-page tabs (left-border indicator). */
   .nav-item.highlight {
-    color: #fff;
-    background: var(--accent);
+    margin: 6px 16px;
+    padding: 10px 14px;
+    background: var(--ds-primary);
+    color: var(--ds-bg);
     border-left-color: transparent;
+    border-radius: 8px;
     font-weight: 500;
-    margin: 4px 12px;
-    padding: 8px 12px;
-    border-radius: 7px;
-    box-shadow: 0 2px 10px rgba(98,114,255,0.25);
-    transition: background 0.15s, transform 0.15s, box-shadow 0.15s;
   }
   .nav-item.highlight:hover {
-    background: var(--accent2);
-    transform: translateX(1px);
-    box-shadow: 0 3px 14px rgba(98,114,255,0.40);
+    background: var(--iv-90);
+    transform: translateY(-1px);
+    box-shadow: 0 10px 25px rgba(0,0,0,0.3);
   }
-  .nav-item.highlight .nav-icon { color: #fff; }
   .nav-item.highlight .nav-arrow {
     margin-left: auto;
-    color: #fff;
-    font-family: var(--font-mono);
-    font-size: 14px;
-    transition: transform 0.15s;
+    font-family: var(--font-body);
+    font-weight: 400;
+    transition: transform var(--dur-base) var(--ease-luxe);
   }
   .nav-item.highlight:hover .nav-arrow { transform: translateX(3px); }
 
-  .nav-icon { font-size: 15px; width: 18px; text-align: center; }
-
   .nav-badge {
     position: absolute;
-    right: 14px;
-    background: var(--accent);
-    color: white;
+    right: 18px;
+    background: var(--sys-yellow);
+    color: var(--ds-bg);
     font-size: 10px;
     font-family: var(--font-mono);
-    font-weight: 600;
-    padding: 1px 6px;
-    border-radius: 8px;
+    font-weight: 500;
+    padding: 2px 7px;
+    border-radius: 999px;
     display: none;
   }
-  .nav-badge.visible { display: inline-block; animation: pulse 1.5s infinite; }
+  .nav-badge.visible { display: inline-block; }
 
   .nav-divider {
     height: 1px;
-    background: var(--border);
-    margin: 8px 16px;
+    background: var(--iv-10);
+    margin: 12px 24px;
   }
 
   /* ── Main content ─────────────────────────────────── */
@@ -220,6 +372,7 @@
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    background: var(--ds-bg);
   }
 
   .panel {
@@ -231,194 +384,264 @@
   .panel.active { display: flex; }
 
   .panel-header {
-    padding: 16px 24px 12px;
-    border-bottom: 1px solid var(--border);
+    padding: 24px 32px 20px;
+    border-bottom: 1px solid var(--iv-10);
     display: flex;
-    align-items: center;
-    gap: 12px;
+    align-items: baseline;
+    gap: 16px;
     flex-shrink: 0;
   }
-
   .panel-title {
-    font-family: var(--font-mono);
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--text);
+    font-family: var(--font-body);
+    font-size: 22px;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    color: var(--ds-primary);
   }
   .panel-subtitle {
-    font-size: 12px;
-    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--iv-60);
     margin-left: auto;
   }
 
   .panel-body {
     flex: 1;
     overflow-y: auto;
-    padding: 20px 24px;
+    padding: 28px 32px 32px;
   }
 
-  /* ── Buttons ──────────────────────────────────────── */
-  .btn {
-    padding: 7px 16px;
-    border-radius: 6px;
-    border: 1px solid var(--border);
-    font-family: var(--font-mono);
-    font-size: 12px;
-    cursor: pointer;
-    transition: all 0.15s;
-    background: var(--surface2);
-    color: var(--text);
-  }
-  .btn:hover    { border-color: var(--accent); color: var(--accent); }
-  .btn:disabled { opacity: 0.4; cursor: not-allowed; }
-  .btn.primary  { background: var(--accent); border-color: var(--accent); color: white; }
-  .btn.primary:hover { background: var(--accent2); border-color: var(--accent2); color: white; }
-  .btn.danger   { border-color: var(--red);   color: var(--red); }
-  .btn.danger:hover  { background: var(--red);   color: white; }
-  .btn.success  { border-color: var(--green); color: var(--green); }
-  .btn.success:hover { background: var(--green); color: #0d0f14; }
-  .btn.sm { padding: 4px 10px; font-size: 11px; }
-
-  /* ── Form ─────────────────────────────────────────── */
-  .field-label {
-    display: block;
-    font-family: var(--font-mono);
-    font-size: 11px;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    color: var(--text-dim);
-    margin-bottom: 5px;
-  }
-
-  input[type=text], input[type=password], select {
-    background: var(--bg);
-    border: 1px solid var(--border);
-    color: var(--text);
-    border-radius: 6px;
-    padding: 7px 10px;
-    font-size: 13px;
-    font-family: var(--font-mono);
-    width: 100%;
-    outline: none;
-    transition: border-color 0.15s;
-  }
-  input[type=text]:focus, input[type=password]:focus, select:focus { border-color: var(--accent); }
-  input::placeholder { color: var(--text-dim); opacity: 0.5; }
-  input[type=checkbox] { accent-color: var(--accent); width: 15px; height: 15px; cursor: pointer; flex-shrink: 0; }
-
-  select {
-    cursor: pointer;
-    appearance: none;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%236b7688' d='M6 8L0 0h12z'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 12px center;
-    padding-right: 32px;
-  }
-  select option { background: var(--surface2); }
-
-  /* ── Cards ────────────────────────────────────────── */
-  .card {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 16px;
-    margin-bottom: 12px;
-  }
-
+  /* ── Section labels & callouts ────────────────────── */
   .section-label {
     font-family: var(--font-mono);
     font-size: 11px;
-    letter-spacing: 1px;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: var(--text-dim);
-    margin-bottom: 10px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--border);
+    color: var(--iv-60);
+    margin: 24px 0 12px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--iv-10);
     display: flex;
-    align-items: center;
-    gap: 8px;
+    align-items: baseline;
+    gap: 10px;
   }
+  .section-label:first-child { margin-top: 0; }
   .section-label .req-note {
-    color: var(--accent);
+    color: var(--iv-40);
     font-size: 10px;
-    letter-spacing: 0;
+    letter-spacing: 0.06em;
     text-transform: none;
+    font-family: var(--font-body);
   }
 
-  .card-title {
-    font-family: var(--font-mono);
+  .callout {
+    background: var(--surface-60);
+    border: 1px solid var(--iv-10);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-bottom: 18px;
     font-size: 13px;
-    font-weight: 600;
-    color: var(--text);
-    margin-bottom: 12px;
+    color: var(--iv-80);
+    line-height: 1.6;
+    backdrop-filter: blur(4px);
+  }
+  .callout a { color: var(--ds-primary); }
+
+  /* ── Cards (signature translucent + backdrop blur) ── */
+  .card {
+    background: var(--surface-60);
+    border: 1px solid var(--iv-10);
+    border-radius: 8px;
+    padding: 22px;
+    margin-bottom: 14px;
+    backdrop-filter: blur(4px);
+    transition: all var(--dur-slow) var(--ease-luxe);
+  }
+  .card.flush { padding: 0; }
+  .card.flush > :first-child { border-top: none; }
+
+  .card-title {
+    font-family: var(--font-body);
+    font-size: 13px;
+    font-weight: 300;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--ds-primary);
+    margin-bottom: 14px;
   }
 
   .field-grid-2 {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 12px;
+    gap: 16px;
   }
+
+  /* ── Form ─────────────────────────────────────────── */
+  .field-label {
+    display: block;
+    font-family: var(--font-body);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--iv-60);
+    margin-bottom: 7px;
+  }
+
+  input[type=text], input[type=password], select, textarea {
+    background: var(--surface-60);
+    border: 1px solid var(--iv-10);
+    color: var(--ds-primary);
+    border-radius: 8px;
+    padding: 11px 14px;
+    font-size: 13px;
+    font-family: var(--font-body);
+    font-weight: 400;
+    width: 100%;
+    outline: none;
+    transition: border-color var(--dur-fast) var(--ease-luxe);
+  }
+  input[type=text]:focus, input[type=password]:focus, select:focus, textarea:focus {
+    border-color: var(--iv-30);
+    outline: 2px solid var(--ds-accent);
+    outline-offset: 2px;
+  }
+  input::placeholder, textarea::placeholder { color: var(--iv-40); }
+
+  input[type=checkbox] {
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    border: 1px solid var(--iv-30);
+    border-radius: 4px;
+    background: var(--surface-60);
+    cursor: pointer;
+    position: relative;
+    flex-shrink: 0;
+    transition: all var(--dur-fast) var(--ease-luxe);
+  }
+  input[type=checkbox]:hover { border-color: var(--ds-primary); }
+  input[type=checkbox]:checked {
+    background: var(--ds-primary);
+    border-color: var(--ds-primary);
+  }
+  input[type=checkbox]:checked::after {
+    content: "";
+    position: absolute;
+    left: 4px; top: 1px;
+    width: 5px; height: 9px;
+    border: solid var(--ds-bg);
+    border-width: 0 1.5px 1.5px 0;
+    transform: rotate(45deg);
+  }
+  input[type=checkbox]:focus-visible { outline: 2px solid var(--ds-accent); outline-offset: 2px; }
+
+  select {
+    cursor: pointer;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23FFFFE3' fill-opacity='0.6' d='M6 8L0 0h12z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 14px center;
+    padding-right: 36px;
+  }
+  select option { background: var(--ds-elevated); color: var(--ds-primary); }
+
+  code {
+    font-family: var(--font-mono);
+    font-size: 0.875em;
+    color: var(--ds-primary);
+    background: var(--iv-05);
+    padding: 1px 6px;
+    border-radius: 4px;
+  }
+
+  .hint {
+    font-size: 12px;
+    color: var(--iv-60);
+    margin-top: 7px;
+    line-height: 1.6;
+  }
+  .field-gap { margin-top: 14px; }
 
   /* ── Channel / tool toggles ───────────────────────── */
   .toggle-row {
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 10px 0;
-    border-bottom: 1px solid var(--border);
+    gap: 12px;
+    padding: 14px 22px;
+    border-bottom: 1px solid var(--iv-10);
     cursor: pointer;
     user-select: none;
+    transition: background var(--dur-fast) var(--ease-luxe);
   }
+  .toggle-row:hover { background: var(--iv-05); }
   .toggle-row:last-child { border-bottom: none; }
   .toggle-label {
-    font-family: var(--font-mono);
+    font-family: var(--font-body);
     font-size: 13px;
     font-weight: 500;
+    color: var(--ds-primary);
   }
-  .toggle-icon { font-size: 16px; }
+  .toggle-icon {
+    width: 32px; height: 32px;
+    border-radius: 8px;
+    background: var(--ds-primary);
+    color: var(--ds-bg);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  .toggle-icon .icon { width: 16px; height: 16px; }
 
   .toggle-body {
-    padding: 14px 0 6px 26px;
-    border-bottom: 1px solid var(--border);
+    padding: 16px 22px 18px 66px;
+    border-bottom: 1px solid var(--iv-10);
   }
   .toggle-body:last-child { border-bottom: none; }
+  .toggle-row.no-body { border-bottom: none; }
 
   /* ── Stat grid ────────────────────────────────────── */
   .stat-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-    gap: 12px;
-    margin-bottom: 20px;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 14px;
+    margin-bottom: 24px;
   }
 
   .stat-card {
-    background: var(--surface);
-    border: 1px solid var(--border);
+    background: var(--surface-60);
+    border: 1px solid var(--iv-10);
     border-radius: 8px;
-    padding: 16px;
+    padding: 20px;
+    backdrop-filter: blur(4px);
   }
 
   .stat-label {
     font-family: var(--font-mono);
-    font-size: 11px;
-    letter-spacing: 1px;
+    font-size: 10px;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: var(--text-dim);
-    margin-bottom: 8px;
+    color: var(--iv-60);
+    margin-bottom: 12px;
   }
 
   .stat-value {
-    font-family: var(--font-mono);
-    font-size: 20px;
-    font-weight: 600;
-    color: var(--text);
+    font-family: var(--font-body);
+    font-size: 24px;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    color: var(--ds-primary);
   }
-  .stat-value.green  { color: var(--green); }
-  .stat-value.red    { color: var(--red); }
-  .stat-value.yellow { color: var(--yellow); }
+  .stat-value.green  { color: var(--sys-green); }
+  .stat-value.red    { color: var(--sys-red); }
+  .stat-value.yellow { color: var(--sys-yellow); }
+  .stat-value.accent { color: var(--ds-accent); }
 
   /* ── Action row ───────────────────────────────────── */
-  .action-row { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 20px; }
+  .action-row { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 28px; }
 
   /* ── Logs ─────────────────────────────────────────── */
   #log-view {
@@ -426,279 +649,289 @@
     overflow-y: auto;
     font-family: var(--font-mono);
     font-size: 12px;
-    line-height: 1.6;
-    padding: 12px 16px;
-    background: #0a0c10;
+    line-height: 1.7;
+    padding: 18px 28px;
+    background: var(--ds-bg);
+    color: var(--iv-80);
   }
 
   .log-line {
     padding: 1px 0;
-    color: var(--text);
     word-break: break-all;
     white-space: pre-wrap;
   }
 
-  /* ── Chips ────────────────────────────────────────── */
+  /* ── Chips / pills ────────────────────────────────── */
   .chip {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 4px;
-    font-family: var(--font-mono);
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 5px 11px;
+    border-radius: 999px;
+    border: 1px solid var(--iv-18);
+    font-family: var(--font-body);
     font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--iv-80);
   }
-  .chip.green { background: rgba(63,185,80,0.15);  color: var(--green); }
-  .chip.dim   { background: rgba(255,255,255,0.04); color: var(--text-dim); }
+  .chip .dot {
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: var(--iv-30);
+    flex-shrink: 0;
+  }
+  .chip.green {
+    border-color: rgba(122,158,144,0.4);
+    color: var(--ds-primary);
+  }
+  .chip.green .dot {
+    background: var(--ds-accent);
+    box-shadow: 0 0 0 3px rgba(122,158,144,0.2);
+  }
+  .chip.dim { color: var(--iv-40); }
 
   /* ── Table ────────────────────────────────────────── */
   .data-table { width: 100%; border-collapse: collapse; }
   .data-table th {
     text-align: left;
-    padding: 8px 12px;
+    padding: 12px 16px;
     font-family: var(--font-mono);
     font-size: 10px;
-    letter-spacing: 1px;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: var(--text-dim);
-    border-bottom: 1px solid var(--border);
+    color: var(--iv-60);
+    font-weight: 500;
+    border-bottom: 1px solid var(--iv-10);
   }
   .data-table td {
-    padding: 10px 12px;
-    border-bottom: 1px solid var(--border);
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--iv-10);
     font-size: 13px;
+    color: var(--ds-primary);
   }
   .data-table tr:last-child td { border-bottom: none; }
-  .data-table tr:hover td { background: var(--surface2); }
+  .data-table tr:hover td { background: var(--iv-05); }
 
   /* ── Pair cards ───────────────────────────────────── */
   .pair-card {
-    background: var(--surface);
-    border: 1px solid var(--border);
+    background: var(--surface-60);
+    border: 1px solid var(--iv-10);
     border-radius: 8px;
-    padding: 14px 16px;
+    padding: 16px 20px;
     margin-bottom: 10px;
     display: flex;
     align-items: center;
     gap: 14px;
+    backdrop-filter: blur(4px);
+    transition: all var(--dur-base) var(--ease-luxe);
   }
-  .pair-card.pending { border-color: var(--yellow); }
+  .pair-card.pending { border-color: rgba(184,168,104,0.35); }
 
   /* ── Save bar ─────────────────────────────────────── */
   .save-bar {
-    padding: 12px 24px;
-    border-top: 1px solid var(--border);
-    background: var(--surface);
+    padding: 16px 32px;
+    border-top: 1px solid var(--iv-10);
+    background: var(--ds-bg);
     display: flex;
     align-items: center;
     justify-content: space-between;
     flex-shrink: 0;
-    gap: 12px;
+    gap: 14px;
   }
 
   /* ── Toast ────────────────────────────────────────── */
   #toast {
     position: fixed;
-    bottom: 24px;
-    right: 24px;
-    padding: 10px 18px;
+    bottom: 28px;
+    right: 28px;
+    padding: 12px 18px;
     border-radius: 8px;
-    font-family: var(--font-mono);
+    font-family: var(--font-body);
     font-size: 13px;
-    background: var(--surface2);
-    border: 1px solid var(--border);
-    color: var(--text);
+    background: var(--ds-elevated);
+    border: 1px solid var(--iv-10);
+    color: var(--ds-primary);
     display: none;
     z-index: 999;
     max-width: 360px;
-    animation: slideIn 0.2s ease;
+    backdrop-filter: blur(4px);
+    box-shadow: 0 10px 25px rgba(0,0,0,0.3);
+    animation: slideIn var(--dur-base) var(--ease-luxe);
   }
   @keyframes slideIn {
-    from { transform: translateY(10px); opacity: 0; }
-    to   { transform: translateY(0);    opacity: 1; }
+    from { transform: translateY(8px); opacity: 0; }
+    to   { transform: translateY(0);   opacity: 1; }
   }
-  #toast.ok  { border-color: var(--green); color: var(--green); }
-  #toast.err { border-color: var(--red);   color: var(--red);   }
+  #toast.ok  { border-color: rgba(122,158,144,0.5); }
+  #toast.err { border-color: rgba(184,128,120,0.5); color: var(--sys-red); }
 
-  /* ── Misc ─────────────────────────────────────────── */
-  ::-webkit-scrollbar { width: 6px; }
+  /* ── Scrollbar ────────────────────────────────────── */
+  ::-webkit-scrollbar { width: 6px; height: 6px; }
   ::-webkit-scrollbar-track { background: transparent; }
-  ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
-  ::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+  ::-webkit-scrollbar-thumb { background: var(--iv-10); border-radius: 3px; }
+  ::-webkit-scrollbar-thumb:hover { background: var(--iv-30); }
 
   .empty-state {
-    color: var(--text-dim);
-    font-family: var(--font-mono);
+    color: var(--iv-40);
+    font-family: var(--font-body);
     font-size: 13px;
-    padding: 32px 0;
+    padding: 40px 0;
     text-align: center;
   }
-  .hint { font-size: 12px; color: var(--text-dim); margin-top: 6px; }
-  code { font-family: var(--font-mono); color: var(--accent); }
-  .field-gap { margin-top: 12px; }
 
-  /* ── Guide steps ─────────────────────────────────── */
-  .guide-section {
-    margin-bottom: 28px;
-  }
+  /* ── Guide / process-step ─────────────────────────── */
+  .guide-section { margin-bottom: 40px; }
+
   .guide-section-title {
-    font-family: var(--font-mono);
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--accent);
-    margin-bottom: 14px;
-    display: flex;
+    display: grid;
+    grid-template-columns: 48px 1fr;
+    gap: 18px;
     align-items: center;
-    gap: 10px;
+    margin-bottom: 22px;
   }
   .guide-section-title .guide-num {
-    background: var(--accent);
-    color: #fff;
-    width: 24px; height: 24px;
-    border-radius: 50%;
+    width: 48px; height: 48px;
+    border-radius: 8px;
+    background: var(--ds-primary);
+    color: var(--ds-bg);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 12px;
-    font-weight: 600;
-    flex-shrink: 0;
+    font-family: var(--font-body);
+    font-weight: 500;
+    font-size: 16px;
   }
+  .guide-section-title .guide-heading {
+    font-family: var(--font-body);
+    font-size: 18px;
+    font-weight: 300;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--ds-primary);
+  }
+  .guide-section-lead {
+    font-size: 13px;
+    color: var(--iv-80);
+    margin-bottom: 18px;
+    line-height: 1.6;
+    padding-left: 66px;
+  }
+
   .step-list {
     list-style: none;
-    padding: 0;
-    counter-reset: step;
+    padding: 0 0 0 66px;
+    margin: 0;
   }
   .step-list li {
     position: relative;
-    padding: 10px 0 10px 36px;
-    border-left: 2px solid var(--border);
-    margin-left: 11px;
-    font-size: 13px;
-    line-height: 1.6;
-    color: var(--text);
+    padding: 4px 0 18px 22px;
+    font-size: 14px;
+    line-height: 1.65;
+    color: var(--ds-primary);
   }
-  .step-list li:last-child { border-left-color: transparent; }
   .step-list li::before {
-    counter-increment: step;
-    content: counter(step);
+    content: "";
     position: absolute;
-    left: -8px;
-    top: 10px;
-    width: 16px; height: 16px;
+    left: 0;
+    top: 11px;
+    width: 6px; height: 6px;
     border-radius: 50%;
-    background: var(--surface2);
-    border: 1px solid var(--border);
-    color: var(--text-dim);
-    font-family: var(--font-mono);
-    font-size: 10px;
-    font-weight: 600;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    background: var(--ds-accent);
   }
   .step-list li a {
-    color: var(--accent2);
-    text-decoration: none;
+    background-image: linear-gradient(var(--ds-accent), var(--ds-accent));
+    background-size: 0 1px;
+    background-repeat: no-repeat;
+    background-position: 0 100%;
+    transition: background-size var(--dur-base) var(--ease-luxe);
+    color: var(--ds-primary);
   }
-  .step-list li a:hover { text-decoration: underline; }
+  .step-list li a:hover { background-size: 100% 1px; }
   .step-list .step-note {
     display: block;
-    font-size: 12px;
-    color: var(--text-dim);
-    margin-top: 4px;
+    font-size: 13px;
+    color: var(--iv-60);
+    margin-top: 6px;
   }
 
-  /* ── Template cards ──────────────────────────────── */
-  .template-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 14px;
-  }
-  .template-card {
-    background: var(--surface);
-    border: 1px solid var(--border);
+  .guide-callout {
+    background: var(--surface-60);
+    border: 1px solid var(--iv-10);
     border-radius: 8px;
-    padding: 18px;
-    transition: border-color 0.15s;
+    padding: 18px 22px;
+    margin-top: 32px;
+    font-size: 13px;
+    color: var(--iv-80);
+    line-height: 1.65;
+    backdrop-filter: blur(4px);
   }
-  .template-card:hover { border-color: var(--accent); }
-  .template-card-name {
-    font-family: var(--font-mono);
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--text);
-    margin-bottom: 8px;
-  }
-  .template-card-desc {
-    font-size: 12px;
-    color: var(--text-dim);
-    line-height: 1.5;
-    margin-bottom: 14px;
-  }
-  .template-card .btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    text-decoration: none;
-  }
+  .guide-callout a { color: var(--ds-primary); }
 
-  /* ── Header branding ──────────────────────────────── */
-  .header-branding {
+  /* ── Allow-all gateway toggle row (standalone card) ── */
+  .gateway-toggle {
     display: flex;
     align-items: center;
-    gap: 6px;
-    font-family: var(--font-mono);
-    font-size: 11px;
-    color: var(--text-dim);
+    gap: 14px;
+    padding: 16px 20px;
   }
-  .header-branding img {
-    width: 16px;
-    height: 16px;
-    border-radius: 3px;
-    object-fit: contain;
-  }
-  .header-branding a {
-    color: var(--text-dim);
-    text-decoration: none;
-    transition: color 0.15s;
-  }
-  .header-branding a:hover { color: var(--accent); }
-
-  /* ── Guide callout ───────────────────────────────── */
-  .guide-callout {
-    background: rgba(98,114,255,0.06);
-    border: 1px solid rgba(98,114,255,0.2);
-    border-radius: 8px;
-    padding: 14px 16px;
-    margin-top: 20px;
+  .gateway-toggle .label {
     font-size: 13px;
-    color: var(--text);
-    line-height: 1.6;
-  }
-  .guide-callout a {
-    color: #e5534b;
-    text-decoration: none;
     font-weight: 500;
+    color: var(--ds-primary);
   }
-  .guide-callout a:hover { text-decoration: underline; }
 </style>
 </head>
 <body x-data="app()" x-init="init()" x-cloak>
 
+<!-- SVG icon sprite — referenced by <svg><use href="#i-name"/></svg> -->
+<svg class="sprite" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <symbol id="i-alert-triangle" viewBox="0 0 24 24"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></symbol>
+    <symbol id="i-rotate-cw" viewBox="0 0 24 24"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></symbol>
+    <symbol id="i-rotate-ccw" viewBox="0 0 24 24"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></symbol>
+    <symbol id="i-zap" viewBox="0 0 24 24"><path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"/></symbol>
+    <symbol id="i-hexagon" viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></symbol>
+    <symbol id="i-activity" viewBox="0 0 24 24"><path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.5.5 0 0 1-.96 0L9.24 3.18a.5.5 0 0 0-.96 0l-2.35 8.36A2 2 0 0 1 4 13H2"/></symbol>
+    <symbol id="i-scroll-text" viewBox="0 0 24 24"><path d="M15 12h-5"/><path d="M15 8h-5"/><path d="M19 17V5a2 2 0 0 0-2-2H4"/><path d="M8 21h12a2 2 0 0 0 2-2v-1a1 1 0 0 0-1-1H11a1 1 0 0 0-1 1v1a2 2 0 1 1-4 0V5a2 2 0 1 0-4 0v2a1 1 0 0 0 1 1h3"/></symbol>
+    <symbol id="i-users" viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></symbol>
+    <symbol id="i-book-open" viewBox="0 0 24 24"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></symbol>
+    <symbol id="i-log-out" viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></symbol>
+    <symbol id="i-send" viewBox="0 0 24 24"><path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z"/><path d="m21.854 2.147-10.94 10.939"/></symbol>
+    <symbol id="i-gamepad-2" viewBox="0 0 24 24"><line x1="6" y1="11" x2="10" y2="11"/><line x1="8" y1="9" x2="8" y2="13"/><line x1="15" y1="12" x2="15.01" y2="12"/><line x1="18" y1="10" x2="18.01" y2="10"/><path d="M17.32 5H6.68a4 4 0 0 0-3.978 3.59c-.006.052-.01.101-.017.152C2.604 9.416 2 14.456 2 16a3 3 0 0 0 3 3c1 0 1.5-.5 2-1l1.414-1.414A2 2 0 0 1 9.828 16h4.344a2 2 0 0 1 1.414.586L17 18c.5.5 1 1 2 1a3 3 0 0 0 3-3c0-1.545-.604-6.584-.685-7.258-.007-.05-.011-.1-.017-.151A4 4 0 0 0 17.32 5z"/></symbol>
+    <symbol id="i-hash" viewBox="0 0 24 24"><line x1="4" y1="9" x2="20" y2="9"/><line x1="4" y1="15" x2="20" y2="15"/><line x1="10" y1="3" x2="8" y2="21"/><line x1="16" y1="3" x2="14" y2="21"/></symbol>
+    <symbol id="i-mail" viewBox="0 0 24 24"><rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></symbol>
+    <symbol id="i-messages-square" viewBox="0 0 24 24"><path d="M14 9a2 2 0 0 1-2 2H6l-4 4V4c0-1.1.9-2 2-2h8a2 2 0 0 1 2 2z"/><path d="M18 9h2a2 2 0 0 1 2 2v11l-4-4h-6a2 2 0 0 1-2-2v-1"/></symbol>
+    <symbol id="i-grid" viewBox="0 0 24 24"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18"/><path d="M3 15h18"/><path d="M9 3v18"/><path d="M15 3v18"/></symbol>
+    <symbol id="i-message-circle" viewBox="0 0 24 24"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/></symbol>
+    <symbol id="i-play" viewBox="0 0 24 24"><polygon points="6 3 20 12 6 21 6 3"/></symbol>
+    <symbol id="i-square" viewBox="0 0 24 24"><rect width="18" height="18" x="3" y="3" rx="2"/></symbol>
+  </defs>
+</svg>
+
 <!-- Header -->
 <div id="header">
-  <img src="https://pbs.twimg.com/profile_images/1816254738234761216/TX7TW-Mp_400x400.jpg"
-       alt="Hermes" style="width:28px;height:28px;border-radius:6px;flex-shrink:0;">
-  <div class="logo">hermes<span>/admin</span></div>
-  <div class="status-dot" :class="gw.state||'stopped'"></div>
-  <div id="status-label" x-text="gw.state||'stopped'"></div>
-  <div class="header-spacer"></div>
-  <div class="header-branding">
-    <span>made with ♥ by</span>
-    <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/heimdall-light.svg" alt="Heimdall">
-    <a href="https://github.com/praveen-ks-2001" target="_blank" rel="noopener">Heimdall</a>
+  <div class="wordmark">
+    <span class="top">hermes</span>
+    <span class="sub">Admin</span>
   </div>
+
+  <div class="status-cluster">
+    <div class="status-dot" :class="gw.state||'stopped'"></div>
+    <div id="status-label" x-text="gw.state||'stopped'"></div>
+  </div>
+
   <div class="header-spacer"></div>
-  <a class="header-issue-link" href="https://github.com/praveen-ks-2001/hermes-agent-template/issues" target="_blank" rel="noopener">⚠ Report issue</a>
-  <button class="header-btn" @click="restartGateway()">↺ Restart</button>
+
+  <a class="header-btn muted" href="https://github.com/kevinledev/hermes-agent-template/issues" target="_blank" rel="noopener">
+    <svg class="icon xs"><use href="#i-alert-triangle"/></svg>
+    Report issue
+  </a>
+  <button class="header-btn" @click="restartGateway()">
+    <svg class="icon xs"><use href="#i-rotate-cw"/></svg>
+    Restart
+  </button>
 </div>
 
 <!-- Layout -->
@@ -709,61 +942,57 @@
 
     <div class="nav-group-label">Setup</div>
     <div class="nav-item" :class="{active: page==='setup'}" @click="page='setup'">
-      <span class="nav-icon">⚡</span>
+      <svg class="icon"><use href="#i-zap"/></svg>
       <span>Setup</span>
     </div>
 
-    <div class="nav-group-label" style="margin-top:8px">Dashboard</div>
+    <div class="nav-group-label">Dashboard</div>
     <div class="nav-item highlight"
          @click="window.location.href='/?force=1'"
          title="Open the native Hermes dashboard — providers, skills, analytics, sessions">
-      <span class="nav-icon">⬢</span>
+      <svg class="icon"><use href="#i-hexagon"/></svg>
       <span>Hermes Dashboard</span>
       <span class="nav-arrow">→</span>
     </div>
 
-    <div class="nav-group-label" style="margin-top:8px">Monitor</div>
+    <div class="nav-group-label">Monitor</div>
     <div class="nav-item"
          :class="{active: page==='status', locked: !isSetupDone}"
          @click="isSetupDone && (page='status')">
-      <span class="nav-icon">◎</span>
+      <svg class="icon"><use href="#i-activity"/></svg>
       <span>Status</span>
     </div>
     <div class="nav-item"
          :class="{active: page==='logs', locked: !isSetupDone}"
          @click="isSetupDone && (page='logs')">
-      <span class="nav-icon">≡</span>
+      <svg class="icon"><use href="#i-scroll-text"/></svg>
       <span>Logs</span>
     </div>
 
-    <div class="nav-group-label" style="margin-top:8px">Manage</div>
+    <div class="nav-group-label">Manage</div>
     <div class="nav-item"
          :class="{active: page==='users', locked: !isSetupDone}"
          @click="isSetupDone && (page='users')">
-      <span class="nav-icon">◈</span>
+      <svg class="icon"><use href="#i-users"/></svg>
       <span>Users</span>
       <span class="nav-badge" :class="{visible: pendingCount>0}" x-text="pendingCount"></span>
     </div>
 
-    <div class="nav-group-label" style="margin-top:8px">Resources</div>
+    <div class="nav-group-label">Resources</div>
     <div class="nav-item" :class="{active: page==='guide'}" @click="page='guide'">
-      <span class="nav-icon">📖</span>
+      <svg class="icon"><use href="#i-book-open"/></svg>
       <span>How to Setup</span>
-    </div>
-    <div class="nav-item" :class="{active: page==='templates'}" @click="page='templates'">
-      <span class="nav-icon">🚀</span>
-      <span>Other Templates</span>
     </div>
 
     <div class="nav-divider" style="margin-top:auto;"></div>
 
     <div class="nav-item danger" @click="resetConfig()">
-      <span class="nav-icon">⊘</span>
+      <svg class="icon"><use href="#i-rotate-ccw"/></svg>
       <span>Reset Config</span>
     </div>
 
     <div class="nav-item" @click="window.location.href='/logout'">
-      <span class="nav-icon">↪</span>
+      <svg class="icon"><use href="#i-log-out"/></svg>
       <span>Sign out</span>
     </div>
 
@@ -780,22 +1009,22 @@
       </div>
       <div class="panel-body">
 
-        <div style="background:rgba(98,114,255,0.06);border:1px solid rgba(98,114,255,0.2);border-radius:8px;padding:10px 14px;margin-bottom:16px;font-size:13px;color:var(--text-dim);">
-          New to Hermes? Head over to the <a href="#" @click.prevent="page='guide'" style="color:var(--accent2);text-decoration:none;font-weight:500;">How to Setup</a> section for a step-by-step guide on getting started.
+        <div class="callout">
+          New to Hermes? Head over to the <a href="#" @click.prevent="page='guide'" class="ds-link">How to Setup</a> section for a step-by-step guide on getting started.
         </div>
 
         <!-- LLM Provider -->
         <div class="section-label">
           LLM Provider
-          <span class="req-note">* required</span>
+          <span class="req-note">— required</span>
         </div>
         <div class="card">
-          <p class="hint" style="margin:0 0 12px;line-height:1.55;">
+          <p class="hint" style="margin:0 0 14px;">
             The dropdown below has the most-used providers. Hermes adds new ones
-            often and this list won't always be perfectly in sync &mdash; but every
+            often and this list won't always be perfectly in sync — but every
             provider Hermes supports is configurable from the
-            <a href="/?force=1" style="color:var(--accent2);text-decoration:none;font-weight:500;">Hermes Dashboard</a>
-            &rarr; <strong>Keys</strong> tab. A typical flow: pick one here (e.g.
+            <a href="/?force=1" class="ds-link">Hermes Dashboard</a>
+            → <strong style="color:var(--ds-primary);font-weight:500;">Keys</strong> tab. A typical flow: pick one here (e.g.
             OpenRouter) to get the agent running, then open the dashboard to add
             or switch to any other provider you need.
           </p>
@@ -830,12 +1059,12 @@
           Messaging Channels
           <span class="req-note">— at least one required</span>
         </div>
-        <div class="card" style="padding: 0 16px;">
+        <div class="card flush">
 
           <!-- Telegram -->
           <div class="toggle-row" @click="channelsEnabled.telegram=!channelsEnabled.telegram; if(!channelsEnabled.telegram) clearChannel('telegram')">
             <input type="checkbox" :checked="channelsEnabled.telegram" @click.stop @change="channelsEnabled.telegram=$event.target.checked; if(!channelsEnabled.telegram) clearChannel('telegram')">
-            <span class="toggle-icon">✈️</span>
+            <span class="toggle-icon"><svg class="icon"><use href="#i-send"/></svg></span>
             <span class="toggle-label">Telegram</span>
           </div>
           <div class="toggle-body" x-show="channelsEnabled.telegram">
@@ -848,7 +1077,7 @@
           <!-- Discord -->
           <div class="toggle-row" @click="channelsEnabled.discord=!channelsEnabled.discord; if(!channelsEnabled.discord) clearChannel('discord')">
             <input type="checkbox" :checked="channelsEnabled.discord" @click.stop @change="channelsEnabled.discord=$event.target.checked; if(!channelsEnabled.discord) clearChannel('discord')">
-            <span class="toggle-icon">🎮</span>
+            <span class="toggle-icon"><svg class="icon"><use href="#i-gamepad-2"/></svg></span>
             <span class="toggle-label">Discord</span>
           </div>
           <div class="toggle-body" x-show="channelsEnabled.discord">
@@ -861,7 +1090,7 @@
           <!-- Slack -->
           <div class="toggle-row" @click="channelsEnabled.slack=!channelsEnabled.slack; if(!channelsEnabled.slack) clearChannel('slack')">
             <input type="checkbox" :checked="channelsEnabled.slack" @click.stop @change="channelsEnabled.slack=$event.target.checked; if(!channelsEnabled.slack) clearChannel('slack')">
-            <span class="toggle-icon">💼</span>
+            <span class="toggle-icon"><svg class="icon"><use href="#i-hash"/></svg></span>
             <span class="toggle-label">Slack</span>
           </div>
           <div class="toggle-body" x-show="channelsEnabled.slack">
@@ -874,7 +1103,7 @@
           <!-- Email -->
           <div class="toggle-row" @click="channelsEnabled.email=!channelsEnabled.email; if(!channelsEnabled.email) clearChannel('email')">
             <input type="checkbox" :checked="channelsEnabled.email" @click.stop @change="channelsEnabled.email=$event.target.checked; if(!channelsEnabled.email) clearChannel('email')">
-            <span class="toggle-icon">📧</span>
+            <span class="toggle-icon"><svg class="icon"><use href="#i-mail"/></svg></span>
             <span class="toggle-label">Email</span>
           </div>
           <div class="toggle-body" x-show="channelsEnabled.email">
@@ -889,7 +1118,7 @@
           <!-- Mattermost -->
           <div class="toggle-row" @click="channelsEnabled.mattermost=!channelsEnabled.mattermost; if(!channelsEnabled.mattermost) clearChannel('mattermost')">
             <input type="checkbox" :checked="channelsEnabled.mattermost" @click.stop @change="channelsEnabled.mattermost=$event.target.checked; if(!channelsEnabled.mattermost) clearChannel('mattermost')">
-            <span class="toggle-icon">🔷</span>
+            <span class="toggle-icon"><svg class="icon"><use href="#i-messages-square"/></svg></span>
             <span class="toggle-label">Mattermost</span>
           </div>
           <div class="toggle-body" x-show="channelsEnabled.mattermost">
@@ -902,7 +1131,7 @@
           <!-- Matrix -->
           <div class="toggle-row" @click="channelsEnabled.matrix=!channelsEnabled.matrix; if(!channelsEnabled.matrix) clearChannel('matrix')">
             <input type="checkbox" :checked="channelsEnabled.matrix" @click.stop @change="channelsEnabled.matrix=$event.target.checked; if(!channelsEnabled.matrix) clearChannel('matrix')">
-            <span class="toggle-icon">🔢</span>
+            <span class="toggle-icon"><svg class="icon"><use href="#i-grid"/></svg></span>
             <span class="toggle-label">Matrix</span>
           </div>
           <div class="toggle-body" x-show="channelsEnabled.matrix">
@@ -914,21 +1143,23 @@
           </div>
 
           <!-- WhatsApp -->
-          <div class="toggle-row" style="border-bottom:none;" @click="channelsEnabled.whatsapp=!channelsEnabled.whatsapp; vars.WHATSAPP_ENABLED=channelsEnabled.whatsapp?'true':'false'">
+          <div class="toggle-row no-body" @click="channelsEnabled.whatsapp=!channelsEnabled.whatsapp; vars.WHATSAPP_ENABLED=channelsEnabled.whatsapp?'true':'false'">
             <input type="checkbox" :checked="channelsEnabled.whatsapp" @click.stop @change="channelsEnabled.whatsapp=$event.target.checked; vars.WHATSAPP_ENABLED=$event.target.checked?'true':'false'">
-            <span class="toggle-icon">💬</span>
+            <span class="toggle-icon"><svg class="icon"><use href="#i-message-circle"/></svg></span>
             <span class="toggle-label">WhatsApp</span>
-            <span style="font-size:11px;color:var(--text-dim);margin-left:8px;">pairing via gateway logs on first run</span>
+            <span style="font-size:11px;color:var(--iv-60);margin-left:8px;">pairing via gateway logs on first run</span>
           </div>
 
         </div>
 
         <!-- Gateway options -->
-        <div class="card" style="display:flex;align-items:center;gap:12px;margin-bottom:12px;">
-          <input type="checkbox" :checked="vars.GATEWAY_ALLOW_ALL_USERS==='true'" @change="vars.GATEWAY_ALLOW_ALL_USERS=$event.target.checked?'true':'false'">
-          <div>
-            <p style="font-size:13px;font-weight:500;">Allow all users</p>
-            <p class="hint" style="margin-top:2px;">Skip per-platform allowlists — use with caution</p>
+        <div class="card" style="padding:0;margin-top:14px;">
+          <div class="gateway-toggle">
+            <input type="checkbox" :checked="vars.GATEWAY_ALLOW_ALL_USERS==='true'" @change="vars.GATEWAY_ALLOW_ALL_USERS=$event.target.checked?'true':'false'">
+            <div>
+              <p class="label">Allow all users</p>
+              <p class="hint" style="margin-top:3px;">Skip per-platform allowlists — use with caution</p>
+            </div>
           </div>
         </div>
 
@@ -937,17 +1168,16 @@
           Tool API Keys
           <span class="req-note">— optional</span>
         </div>
-        <div class="card" style="padding: 0 16px;">
+        <div class="card flush">
           <template x-for="(t, i) in tools" :key="t.key">
             <div>
-              <div class="toggle-row" :style="i===tools.length-1 && !toolsEnabled[t.key] ? 'border-bottom:none' : ''"
+              <div class="toggle-row"
                    @click="toolsEnabled[t.key]=!toolsEnabled[t.key]; if(!toolsEnabled[t.key]) clearTool(t)">
                 <input type="checkbox" :checked="toolsEnabled[t.key]" @click.stop
                        @change="toolsEnabled[t.key]=$event.target.checked; if(!toolsEnabled[t.key]) clearTool(t)">
                 <span class="toggle-label" x-text="t.label"></span>
               </div>
-              <div class="toggle-body" x-show="toolsEnabled[t.key]"
-                   :style="i===tools.length-1 ? 'border-bottom:none' : ''">
+              <div class="toggle-body" x-show="toolsEnabled[t.key]">
                 <div>
                   <label class="field-label">API Key</label>
                   <input :type="t.secret?'password':'text'" :value="vars[t.key]||''" @input="vars[t.key]=$event.target.value">
@@ -963,7 +1193,7 @@
 
       </div>
       <div class="save-bar">
-        <label style="display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text-dim);cursor:pointer;">
+        <label style="display:flex;align-items:center;gap:10px;font-size:13px;color:var(--iv-80);cursor:pointer;">
           <input type="checkbox" x-model="restartOnSave"> Restart gateway after save
         </label>
         <div style="display:flex;gap:10px;align-items:center;">
@@ -993,11 +1223,11 @@
             <div class="stat-label">Gateway State</div>
             <div class="stat-value"
                  :class="{green: gw.state==='running', red: gw.state==='error'||gw.state==='crashed', yellow: gw.state==='starting'||gw.state==='stopping'}"
-                 x-text="gw.state||'stopped'"></div>
+                 x-text="gw.state||'stopped'" style="font-size:18px;letter-spacing:0.04em;text-transform:uppercase;font-weight:300;"></div>
           </div>
           <div class="stat-card">
             <div class="stat-label">Uptime</div>
-            <div class="stat-value" style="font-size:16px;" x-text="gw.uptime!=null ? fmtUptime(gw.uptime) : '—'"></div>
+            <div class="stat-value" style="font-size:18px;" x-text="gw.uptime!=null ? fmtUptime(gw.uptime) : '—'"></div>
           </div>
           <div class="stat-card">
             <div class="stat-label">Pending Pairs</div>
@@ -1005,35 +1235,47 @@
           </div>
           <div class="stat-card">
             <div class="stat-label">Model</div>
-            <div class="stat-value" style="font-size:12px;word-break:break-all;" x-text="vars.LLM_MODEL||'—'"></div>
+            <div class="stat-value" style="font-size:13px;font-family:var(--font-mono);font-weight:400;word-break:break-all;" x-text="vars.LLM_MODEL||'—'"></div>
           </div>
         </div>
 
         <div class="action-row">
-          <button class="btn success" @click="startGw()"        :disabled="gw.state==='running'">▶ Start</button>
-          <button class="btn danger"  @click="stopGw()"         :disabled="gw.state==='stopped'">■ Stop</button>
-          <button class="btn"         @click="restartGateway()">↺ Restart</button>
+          <button class="btn success" @click="startGw()" :disabled="gw.state==='running'">
+            <svg class="icon xs"><use href="#i-play"/></svg> Start
+          </button>
+          <button class="btn danger" @click="stopGw()" :disabled="gw.state==='stopped'">
+            <svg class="icon xs"><use href="#i-square"/></svg> Stop
+          </button>
+          <button class="btn" @click="restartGateway()">
+            <svg class="icon xs"><use href="#i-rotate-cw"/></svg> Restart
+          </button>
         </div>
 
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:18px;">
           <div>
-            <div class="section-label">Providers</div>
-            <div class="card" style="padding:0;overflow:hidden;">
+            <div class="section-label" style="margin-top:0;">Providers</div>
+            <div class="card flush">
               <template x-for="(info,name) in status.providers||{}" :key="name">
-                <div style="display:flex;align-items:center;justify-content:space-between;padding:9px 14px;border-bottom:1px solid var(--border);">
+                <div style="display:flex;align-items:center;justify-content:space-between;padding:12px 18px;border-bottom:1px solid var(--iv-10);">
                   <span style="font-size:13px;" x-text="name"></span>
-                  <span class="chip" :class="info.configured?'green':'dim'" x-text="info.configured?'✓ set':'—'"></span>
+                  <span class="chip" :class="info.configured?'green':'dim'">
+                    <span class="dot"></span>
+                    <span x-text="info.configured?'Configured':'Not set'"></span>
+                  </span>
                 </div>
               </template>
             </div>
           </div>
           <div>
-            <div class="section-label">Channels</div>
-            <div class="card" style="padding:0;overflow:hidden;">
+            <div class="section-label" style="margin-top:0;">Channels</div>
+            <div class="card flush">
               <template x-for="(info,name) in status.channels||{}" :key="name">
-                <div style="display:flex;align-items:center;justify-content:space-between;padding:9px 14px;border-bottom:1px solid var(--border);">
+                <div style="display:flex;align-items:center;justify-content:space-between;padding:12px 18px;border-bottom:1px solid var(--iv-10);">
                   <span style="font-size:13px;" x-text="name"></span>
-                  <span class="chip" :class="info.configured?'green':'dim'" x-text="info.configured?'✓ set':'—'"></span>
+                  <span class="chip" :class="info.configured?'green':'dim'">
+                    <span class="dot"></span>
+                    <span x-text="info.configured?'Configured':'Not set'"></span>
+                  </span>
                 </div>
               </template>
             </div>
@@ -1065,13 +1307,13 @@
       </div>
       <div class="panel-body">
 
-        <div class="section-label">Pending Pairing Requests</div>
+        <div class="section-label" style="margin-top:0;">Pending Pairing Requests</div>
         <div class="empty-state" x-show="pending.length===0">No pending requests. Unauthorized users who message your bot will appear here.</div>
         <template x-for="r in pending" :key="r.platform+r.code">
           <div class="pair-card pending">
             <div style="flex:1;">
-              <div style="font-size:13px;font-weight:500;" x-text="r.user_name||r.user_id"></div>
-              <div class="hint" style="margin-top:3px;">
+              <div style="font-size:14px;font-weight:500;color:var(--ds-primary);" x-text="r.user_name||r.user_id"></div>
+              <div class="hint" style="margin-top:4px;">
                 <span x-text="r.platform"></span>
                 <span x-show="r.user_name" x-text="' · #'+r.user_id"></span>
                 <span x-text="' · '+r.age_minutes+'m ago'"></span>
@@ -1084,9 +1326,9 @@
           </div>
         </template>
 
-        <div class="section-label" style="margin-top:20px;">Approved Users</div>
+        <div class="section-label">Approved Users</div>
         <div class="empty-state" x-show="approved.length===0">No approved users yet.</div>
-        <div class="card" style="padding:0;overflow:hidden;" x-show="approved.length>0">
+        <div class="card flush" x-show="approved.length>0">
           <table class="data-table">
             <thead>
               <tr>
@@ -1099,12 +1341,12 @@
             <tbody>
               <template x-for="u in approved" :key="u.platform+u.user_id">
                 <tr>
-                  <td style="color:var(--accent);" x-text="u.platform"></td>
+                  <td style="font-family:var(--font-mono);font-size:12px;color:var(--iv-80);" x-text="u.platform"></td>
                   <td>
                     <span x-text="u.user_name||u.user_id"></span>
-                    <span style="color:var(--text-dim);font-size:12px;font-family:var(--font-mono);" x-show="u.user_name" x-text="' #'+u.user_id"></span>
+                    <span style="color:var(--iv-40);font-size:12px;font-family:var(--font-mono);" x-show="u.user_name" x-text="' #'+u.user_id"></span>
                   </td>
-                  <td style="color:var(--text-dim);font-size:12px;" x-text="fmtDate(u.approved_at)"></td>
+                  <td style="color:var(--iv-60);font-size:12px;font-family:var(--font-mono);" x-text="fmtDate(u.approved_at)"></td>
                   <td style="text-align:right;">
                     <button class="btn sm danger" @click="revoke(u.platform,u.user_id)">Revoke</button>
                   </td>
@@ -1120,7 +1362,7 @@
     <!-- ── Guide panel ─────────────────────────────── -->
     <div class="panel" :class="{active: page==='guide'}">
       <div class="panel-header">
-        <div class="panel-title">How to Setup</div>
+        <div class="panel-title">How to setup</div>
         <div class="panel-subtitle">Get your Hermes Agent running in minutes</div>
       </div>
       <div class="panel-body">
@@ -1128,15 +1370,15 @@
         <!-- Part 1: LLM API Key -->
         <div class="guide-section">
           <div class="guide-section-title">
-            <span class="guide-num">1</span>
-            Get a Free LLM API Key
+            <span class="guide-num">01</span>
+            <span class="guide-heading">Get a free LLM API key</span>
           </div>
           <ol class="step-list">
             <li>
               Go to <a href="https://openrouter.ai" target="_blank" rel="noopener">openrouter.ai</a> and create a free account.
             </li>
             <li>
-              Once logged in, go to <a href="https://openrouter.ai/workspaces/default/keys" target="_blank" rel="noopener">openrouter.ai/workspaces/default/keys</a> and click <strong>Create Key</strong>.
+              Once logged in, go to <a href="https://openrouter.ai/workspaces/default/keys" target="_blank" rel="noopener">openrouter.ai/workspaces/default/keys</a> and click <strong style="color:var(--ds-primary);font-weight:500;">Create Key</strong>.
               <span class="step-note">Copy the generated API key — it starts with <code>sk-or-...</code></span>
             </li>
             <li>
@@ -1145,11 +1387,11 @@
               <span class="step-note">Browse all available models at <a href="https://openrouter.ai/models" target="_blank" rel="noopener">openrouter.ai/models</a> — filter by "Free" to see no-cost options.</span>
             </li>
             <li>
-              Head over to the <strong>Setup</strong> page (left sidebar), select <strong>OpenRouter</strong> as provider, paste your API key, and enter the model name.
+              Head over to the <strong style="color:var(--ds-primary);font-weight:500;">Setup</strong> page (left sidebar), select <strong style="color:var(--ds-primary);font-weight:500;">OpenRouter</strong> as provider, paste your API key, and enter the model name.
               <span class="step-note">
                 Want a different provider (Anthropic, DeepSeek, Groq, Cerebras, Mistral, etc.)? Open the
-                <a href="/?force=1" style="color:var(--accent2);">Hermes Dashboard</a> from the sidebar — the
-                <strong>Keys</strong> tab lists every provider Hermes supports out of the box, plus
+                <a href="/?force=1">Hermes Dashboard</a> from the sidebar — the
+                <strong style="color:var(--ds-primary);font-weight:500;">Keys</strong> tab lists every provider Hermes supports out of the box, plus
                 skills, toolsets, and analytics you can configure from there.
               </span>
             </li>
@@ -1159,11 +1401,11 @@
         <!-- Part 2: Telegram -->
         <div class="guide-section">
           <div class="guide-section-title">
-            <span class="guide-num">2</span>
-            Connect a Messaging Platform
+            <span class="guide-num">02</span>
+            <span class="guide-heading">Connect a messaging platform</span>
           </div>
-          <p style="font-size:13px;color:var(--text-dim);margin-bottom:14px;">
-            Hermes Agent works through messaging platforms. You need to connect at least one. The easiest to set up is <strong style="color:var(--text);">Telegram</strong>.
+          <p class="guide-section-lead">
+            Hermes Agent works through messaging platforms. You need to connect at least one. The easiest to set up is <strong style="color:var(--ds-primary);font-weight:500;">Telegram</strong>.
           </p>
           <ol class="step-list">
             <li>
@@ -1173,64 +1415,27 @@
               Send <code>/newbot</code> and follow the prompts — give your bot a name and username.
             </li>
             <li>
-              BotFather will reply with a <strong>Bot Token</strong> — it looks like <code>1234567890:ABCdefGhIjKlMnOpQrStUvWxYz</code>.
+              BotFather will reply with a <strong style="color:var(--ds-primary);font-weight:500;">Bot Token</strong> — it looks like <code>1234567890:ABCdefGhIjKlMnOpQrStUvWxYz</code>.
               <span class="step-note">Copy this token.</span>
             </li>
             <li>
-              Go to the <strong>Setup</strong> page, enable <strong>Telegram</strong> under Messaging Channels, and paste the Bot Token.
+              Go to the <strong style="color:var(--ds-primary);font-weight:500;">Setup</strong> page, enable <strong style="color:var(--ds-primary);font-weight:500;">Telegram</strong> under Messaging Channels, and paste the Bot Token.
             </li>
             <li>
-              For <strong>Allowed User IDs</strong>, if you're just starting out, enter <code>*</code> to allow all users.
+              For <strong style="color:var(--ds-primary);font-weight:500;">Allowed User IDs</strong>, if you're just starting out, enter <code>*</code> to allow all users.
               <span class="step-note">You can restrict access later by specifying individual Telegram user IDs.</span>
             </li>
             <li>
-              Click <strong>Save & Start</strong> on the bottom right — your Hermes Agent is now live!
+              Click <strong style="color:var(--ds-primary);font-weight:500;">Save &amp; Start</strong> on the bottom right — your Hermes Agent is now live.
             </li>
           </ol>
         </div>
 
         <!-- Issue callout -->
         <div class="guide-callout">
-          Facing an issue or something not working as expected? <a href="https://github.com/praveen-ks-2001/hermes-agent-template/issues" target="_blank" rel="noopener">Create a GitHub issue</a> and we'll help you out.
+          Facing an issue or something not working as expected? <a href="https://github.com/kevinledev/hermes-agent-template/issues" target="_blank" rel="noopener" class="ds-link">Create a GitHub issue</a> and we'll help you out.
         </div>
 
-      </div>
-    </div>
-
-    <!-- ── Other Templates panel ───────────────────── -->
-    <div class="panel" :class="{active: page==='templates'}">
-      <div class="panel-header">
-        <div class="panel-title">Other Templates</div>
-        <div class="panel-subtitle">Deploy more AI agents on Railway</div>
-      </div>
-      <div class="panel-body">
-        <p style="font-size:13px;color:var(--text-dim);margin-bottom:18px;">
-          Explore other AI agent templates you can deploy on Railway with one click.
-        </p>
-
-        <div class="template-grid">
-
-          <div class="template-card">
-            <div class="template-card-name">OpenClaw</div>
-            <div class="template-card-desc">
-              Self-hosted OpenClaw agent — deploy and manage your own OpenClaw instance on Railway.
-            </div>
-            <a class="btn primary" href="https://railway.com/deploy/self-host-openclaw?referralCode=QXdhdr&utm_medium=integration&utm_source=template&utm_campaign=generic" target="_blank" rel="noopener">
-              Deploy on Railway
-            </a>
-          </div>
-
-          <div class="template-card">
-            <div class="template-card-name">Paperclip</div>
-            <div class="template-card-desc">
-              Paperclip AI Company — deploy your own Paperclip AI agent instance on Railway.
-            </div>
-            <a class="btn primary" href="https://railway.com/deploy/paperclip-ai-company?referralCode=QXdhdr&utm_medium=integration&utm_source=template&utm_campaign=generic" target="_blank" rel="noopener">
-              Deploy on Railway
-            </a>
-          </div>
-
-        </div>
       </div>
     </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -868,6 +868,139 @@
   }
   .guide-callout a { color: var(--ds-primary); }
 
+  /* ── File browser ────────────────────────────────── */
+  .file-browser {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+    gap: 20px;
+    min-height: 0;
+  }
+  .file-main, .file-aside { min-width: 0; }
+  .path-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+  .path-pill {
+    flex: 1;
+    min-width: 0;
+    border: 1px solid var(--iv-10);
+    border-radius: 8px;
+    background: var(--surface-60);
+    color: var(--ds-primary);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    padding: 8px 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .file-table-wrap {
+    min-height: 380px;
+    max-height: calc(100vh - 270px);
+    overflow: auto;
+  }
+  .file-name {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    max-width: 100%;
+    border: 0;
+    background: transparent;
+    color: var(--ds-primary);
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+  .file-name:hover { color: var(--ds-accent); }
+  .file-entry-icon {
+    width: 26px;
+    color: var(--iv-40);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    flex-shrink: 0;
+  }
+  .file-preview {
+    margin-top: 16px;
+    border: 1px solid var(--iv-10);
+    border-radius: 8px;
+    background: #0b0b0a;
+    overflow: hidden;
+  }
+  .file-preview-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--iv-10);
+    background: var(--ds-surface);
+  }
+  .file-preview-title {
+    flex: 1;
+    min-width: 0;
+    color: var(--iv-80);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .file-preview pre {
+    max-height: 42vh;
+    overflow: auto;
+    padding: 16px;
+    color: var(--iv-90);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .file-doc-list { padding: 0 18px; }
+  .file-doc-link {
+    display: block;
+    width: 100%;
+    padding: 14px 0;
+    border: 0;
+    border-bottom: 1px solid var(--iv-10);
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+  }
+  .file-doc-link:last-child { border-bottom: 0; }
+  .file-doc-path {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--ds-accent);
+    font-family: var(--font-mono);
+    font-size: 12px;
+  }
+  .file-doc-label {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--ds-primary);
+    font-size: 13px;
+    font-weight: 500;
+  }
+  .file-doc-desc {
+    display: block;
+    color: var(--iv-60);
+    font-size: 12px;
+    line-height: 1.5;
+  }
+  .file-note {
+    color: var(--iv-60);
+    font-size: 13px;
+    line-height: 1.6;
+  }
+  @media (max-width: 1180px) {
+    .file-browser { grid-template-columns: 1fr; }
+    .file-table-wrap { max-height: none; }
+  }
+
   /* ── Allow-all gateway toggle row (standalone card) ── */
   .gateway-toggle {
     display: flex;
@@ -895,6 +1028,7 @@
     <symbol id="i-activity" viewBox="0 0 24 24"><path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.5.5 0 0 1-.96 0L9.24 3.18a.5.5 0 0 0-.96 0l-2.35 8.36A2 2 0 0 1 4 13H2"/></symbol>
     <symbol id="i-scroll-text" viewBox="0 0 24 24"><path d="M15 12h-5"/><path d="M15 8h-5"/><path d="M19 17V5a2 2 0 0 0-2-2H4"/><path d="M8 21h12a2 2 0 0 0 2-2v-1a1 1 0 0 0-1-1H11a1 1 0 0 0-1 1v1a2 2 0 1 1-4 0V5a2 2 0 1 0-4 0v2a1 1 0 0 0 1 1h3"/></symbol>
     <symbol id="i-users" viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></symbol>
+    <symbol id="i-folder" viewBox="0 0 24 24"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></symbol>
     <symbol id="i-book-open" viewBox="0 0 24 24"><path d="M12 7v14"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/></symbol>
     <symbol id="i-log-out" viewBox="0 0 24 24"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></symbol>
     <symbol id="i-send" viewBox="0 0 24 24"><path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z"/><path d="m21.854 2.147-10.94 10.939"/></symbol>
@@ -975,6 +1109,12 @@
       <svg class="icon"><use href="#i-users"/></svg>
       <span>Users</span>
       <span class="nav-badge" :class="{visible: pendingCount>0}" x-text="pendingCount"></span>
+    </div>
+    <div class="nav-item"
+         :class="{active: page==='files'}"
+         @click="openFiles()">
+      <svg class="icon"><use href="#i-folder"/></svg>
+      <span>Files</span>
     </div>
 
     <div class="nav-group-label">Resources</div>
@@ -1357,6 +1497,90 @@
       </div>
     </div>
 
+    <!-- ── Files panel ─────────────────────────────── -->
+    <div class="panel" :class="{active: page==='files'}">
+      <div class="panel-header">
+        <div class="panel-title">Files</div>
+        <div class="panel-subtitle">Read-only container filesystem browser</div>
+      </div>
+      <div class="panel-body">
+        <div class="file-browser">
+          <div class="file-main">
+            <div class="path-bar">
+              <button class="btn sm" @click="loadFiles(fileBrowser.parent)" :disabled="!fileBrowser.parent">Up</button>
+              <div class="path-pill" x-text="fileBrowser.path || '/data'"></div>
+              <button class="btn sm" @click="loadFiles(fileBrowser.path)">Refresh</button>
+            </div>
+
+            <div class="card flush file-table-wrap">
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Size</th>
+                    <th>Modified</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <template x-for="entry in fileBrowser.entries" :key="entry.path">
+                    <tr>
+                      <td>
+                        <button class="file-name" @click="openFileEntry(entry)">
+                          <span class="file-entry-icon" x-text="fileIcon(entry)"></span>
+                          <span x-text="entry.name"></span>
+                        </button>
+                      </td>
+                      <td style="font-family:var(--font-mono);font-size:12px;color:var(--iv-60);" x-text="entry.type"></td>
+                      <td style="font-family:var(--font-mono);font-size:12px;color:var(--iv-60);" x-text="formatBytes(entry.size)"></td>
+                      <td style="font-family:var(--font-mono);font-size:12px;color:var(--iv-60);" x-text="formatFileDate(entry.modified)"></td>
+                      <td style="text-align:right;">
+                        <a class="btn sm" x-show="entry.downloadable" :href="downloadUrl(entry.path)">Download</a>
+                      </td>
+                    </tr>
+                  </template>
+                </tbody>
+              </table>
+              <div class="empty-state" x-show="!fileBrowser.loading && fileBrowser.entries.length===0 && !fileBrowser.error">No files found.</div>
+              <div class="empty-state" x-show="fileBrowser.loading">Loading files...</div>
+              <div class="empty-state" x-show="fileBrowser.error" x-text="fileBrowser.error"></div>
+            </div>
+
+            <div class="file-preview" x-show="fileBrowser.preview">
+              <div class="file-preview-header">
+                <div class="file-preview-title" x-text="fileBrowser.preview?.path"></div>
+                <span class="chip dim" x-show="fileBrowser.preview?.truncated">truncated</span>
+                <a class="btn sm" :href="downloadUrl(fileBrowser.preview?.path || '')">Download</a>
+                <button class="btn sm" @click="fileBrowser.preview=null">Close</button>
+              </div>
+              <pre x-text="fileBrowser.preview?.content"></pre>
+            </div>
+          </div>
+
+          <aside class="file-aside">
+            <div class="section-label" style="margin-top:0;">Filesystem notes</div>
+            <div class="card">
+              <p class="file-note" style="margin-bottom:4px;">
+                Files opens at <code>/data</code>. This Railway template sets <code>HOME=/data</code>
+                and <code>HERMES_HOME=/data/.hermes</code>. Official Hermes Docker examples often use
+                <code>/opt/data</code> instead.
+              </p>
+              <div class="file-doc-list">
+                <template x-for="doc in fileBrowser.docs" :key="doc.path">
+                  <button class="file-doc-link" @click="loadFiles(doc.path)">
+                    <span class="file-doc-path" x-text="doc.path"></span>
+                    <span class="file-doc-label" x-text="doc.label"></span>
+                    <span class="file-doc-desc" x-text="doc.description"></span>
+                  </button>
+                </template>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+
     <!-- ── Guide panel ─────────────────────────────── -->
     <div class="panel" :class="{active: page==='guide'}">
       <div class="panel-header">
@@ -1464,6 +1688,16 @@ function app() {
     logs: [],
     pending: [],
     approved: [],
+    fileBrowser: {
+      path: '/data',
+      parent: null,
+      entries: [],
+      docs: [],
+      note: '',
+      preview: null,
+      loading: false,
+      error: '',
+    },
     saving: false,
     restartOnSave: true,
     // True only when the SERVER has a persisted complete config.
@@ -1634,6 +1868,92 @@ function app() {
       if (!confirm('Revoke access for this user?')) return;
       await fetch('/setup/api/pairing/revoke', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({platform,user_id}) });
       this.notify('Revoked', true); await this.loadPairing();
+    },
+
+    async openFiles(path) {
+      this.page = 'files';
+      await this.loadFiles(path || this.fileBrowser.path || '/data');
+    },
+
+    async loadFiles(path) {
+      if (!path) return;
+      this.fileBrowser.loading = true;
+      this.fileBrowser.error = '';
+      try {
+        const r = await fetch('/setup/api/files/list?path=' + encodeURIComponent(path));
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) {
+          this.fileBrowser.error = d.error || 'Failed to load files';
+          this.fileBrowser.docs = d.docs || this.fileBrowser.docs || [];
+          this.fileBrowser.note = d.note || this.fileBrowser.note || '';
+          this.fileBrowser.entries = [];
+          this.fileBrowser.preview = null;
+          return;
+        }
+        this.fileBrowser.path = d.path || path;
+        this.fileBrowser.parent = d.parent || null;
+        this.fileBrowser.entries = d.entries || [];
+        this.fileBrowser.docs = d.docs || [];
+        this.fileBrowser.note = d.note || '';
+        this.fileBrowser.preview = null;
+      } catch(e) {
+        this.fileBrowser.error = 'Failed to load files: ' + e.message;
+      } finally {
+        this.fileBrowser.loading = false;
+      }
+    },
+
+    async openFileEntry(entry) {
+      if (entry.type === 'directory' || entry.type === 'symlink') {
+        await this.loadFiles(entry.path);
+        return;
+      }
+      if (entry.previewable) {
+        await this.previewFile(entry.path);
+      }
+    },
+
+    async previewFile(path) {
+      try {
+        const r = await fetch('/setup/api/files/preview?path=' + encodeURIComponent(path));
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) {
+          this.notify(d.error || 'Preview failed', false);
+          return;
+        }
+        this.fileBrowser.preview = d;
+      } catch(e) {
+        this.notify('Preview failed: ' + e.message, false);
+      }
+    },
+
+    downloadUrl(path) {
+      return '/setup/api/files/download?path=' + encodeURIComponent(path);
+    },
+
+    fileIcon(entry) {
+      if (entry.type === 'directory') return 'dir';
+      if (entry.type === 'symlink') return 'lnk';
+      if (entry.type === 'file') return 'txt';
+      return '---';
+    },
+
+    formatBytes(size) {
+      if (size == null) return '—';
+      if (size < 1024) return `${size} B`;
+      const units = ['KB', 'MB', 'GB', 'TB'];
+      let value = size / 1024;
+      let unit = units[0];
+      for (let i = 1; i < units.length && value >= 1024; i++) {
+        value = value / 1024;
+        unit = units[i];
+      }
+      return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} ${unit}`;
+    },
+
+    formatFileDate(ts) {
+      if (!ts) return '—';
+      return new Date(ts * 1000).toLocaleString(undefined, {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit'});
     },
 
     fmtDate(ts) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -318,7 +318,6 @@
     border-left-color: var(--ds-primary);
     background: var(--iv-05);
   }
-  .nav-item.locked { opacity: 0.3; cursor: not-allowed; pointer-events: none; }
   .nav-item.danger { color: var(--iv-60); }
   .nav-item.danger:hover { color: var(--sys-red); background: rgba(184,128,120,0.06); border-left-color: var(--sys-red); }
 
@@ -957,22 +956,22 @@
 
     <div class="nav-group-label">Monitor</div>
     <div class="nav-item"
-         :class="{active: page==='status', locked: !isSetupDone}"
-         @click="isSetupDone && (page='status')">
+         :class="{active: page==='status'}"
+         @click="page='status'">
       <svg class="icon"><use href="#i-activity"/></svg>
       <span>Status</span>
     </div>
     <div class="nav-item"
-         :class="{active: page==='logs', locked: !isSetupDone}"
-         @click="isSetupDone && (page='logs')">
+         :class="{active: page==='logs'}"
+         @click="page='logs'">
       <svg class="icon"><use href="#i-scroll-text"/></svg>
       <span>Logs</span>
     </div>
 
     <div class="nav-group-label">Manage</div>
     <div class="nav-item"
-         :class="{active: page==='users', locked: !isSetupDone}"
-         @click="isSetupDone && (page='users')">
+         :class="{active: page==='users'}"
+         @click="page='users'">
       <svg class="icon"><use href="#i-users"/></svg>
       <span>Users</span>
       <span class="nav-badge" :class="{visible: pendingCount>0}" x-text="pendingCount"></span>
@@ -1016,7 +1015,7 @@
         <!-- LLM Provider -->
         <div class="section-label">
           LLM Provider
-          <span class="req-note">— required</span>
+          <span class="req-note">— optional in setup</span>
         </div>
         <div class="card">
           <p class="hint" style="margin:0 0 14px;">
@@ -1024,9 +1023,8 @@
             often and this list won't always be perfectly in sync — but every
             provider Hermes supports is configurable from the
             <a href="/?force=1" class="ds-link">Hermes Dashboard</a>
-            → <strong style="color:var(--ds-primary);font-weight:500;">Keys</strong> tab. A typical flow: pick one here (e.g.
-            OpenRouter) to get the agent running, then open the dashboard to add
-            or switch to any other provider you need.
+            → <strong style="color:var(--ds-primary);font-weight:500;">Keys</strong> tab. You can add a provider here for a quick start,
+            or open the dashboard to configure providers there.
           </p>
           <div>
             <label class="field-label">Provider</label>
@@ -1046,11 +1044,11 @@
                    :placeholder="selectedProvider ? (providerMap[selectedProvider]?.placeholder||'Paste your API key') : ''">
           </div>
 
-          <div class="field-gap" x-show="selectedProvider">
-            <label class="field-label">LLM Model</label>
+          <div class="field-gap" x-show="selectedProvider && selectedProvider !== 'OpenRouter'">
+            <label class="field-label">Model</label>
             <input type="text" :value="vars.LLM_MODEL||''" @input="vars.LLM_MODEL=$event.target.value"
                    placeholder="e.g. openai/gpt-4o-mini  or  deepseek/deepseek-chat">
-            <p class="hint">OpenRouter format: <code>provider/model-name</code></p>
+            <p class="hint">Optional here if you prefer to choose a model from the Hermes Dashboard.</p>
           </div>
         </div>
 
@@ -1387,7 +1385,7 @@
               <span class="step-note">Browse all available models at <a href="https://openrouter.ai/models" target="_blank" rel="noopener">openrouter.ai/models</a> — filter by "Free" to see no-cost options.</span>
             </li>
             <li>
-              Head over to the <strong style="color:var(--ds-primary);font-weight:500;">Setup</strong> page (left sidebar), select <strong style="color:var(--ds-primary);font-weight:500;">OpenRouter</strong> as provider, paste your API key, and enter the model name.
+              Head over to the <strong style="color:var(--ds-primary);font-weight:500;">Setup</strong> page (left sidebar), select <strong style="color:var(--ds-primary);font-weight:500;">OpenRouter</strong> as provider, and paste your API key.
               <span class="step-note">
                 Want a different provider (Anthropic, DeepSeek, Groq, Cerebras, Mistral, etc.)? Open the
                 <a href="/?force=1">Hermes Dashboard</a> from the sidebar — the
@@ -1469,7 +1467,6 @@ function app() {
     saving: false,
     restartOnSave: true,
     // True only when the SERVER has a persisted complete config.
-    // Distinct from isSetupDone, which tracks the in-memory form.
     savedConfigComplete: false,
 
     tools,
@@ -1499,11 +1496,6 @@ function app() {
     toolsEnabled: Object.fromEntries(tools.map(t => [t.key, false])),
 
     get pendingCount() { return this.pending.length; },
-
-    get isSetupDone() {
-      const keys = Object.values(this.providerMap).map(p => p.key);
-      return !!(this.vars.LLM_MODEL && keys.some(k => this.vars[k]));
-    },
 
     onProviderChange() {
       // Clear keys from other providers when switching

--- a/tests/test_file_browser.py
+++ b/tests/test_file_browser.py
@@ -1,0 +1,84 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from starlette.testclient import TestClient
+
+import server
+
+
+class FileBrowserApiTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.data = self.root / "data"
+        self.data.mkdir()
+        (self.data / "notes.txt").write_text("hello from hermes\n")
+        (self.data / "nested").mkdir()
+
+        self.client = TestClient(server.app)
+        self.client.cookies.set(server.COOKIE_NAME, server._make_auth_token())
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def get(self, path):
+        return self.client.get(path)
+
+    def test_files_endpoint_requires_admin_auth(self):
+        response = TestClient(server.app).get("/setup/api/files/list")
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_file_browser_defaults_to_data_directory_and_includes_docs_links(self):
+        with patch.object(server, "FILE_BROWSER_DEFAULT_PATH", self.data):
+            response = self.get("/setup/api/files/list")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["path"], str(self.data))
+        self.assertEqual(body["parent"], str(self.root))
+        self.assertIn(
+            {
+                "path": "/data/.hermes",
+                "label": "Hermes runtime home",
+                "description": "Persistent Hermes config, sessions, logs, memories, skills, cron, hooks, and caches for this Railway template.",
+            },
+            body["docs"],
+        )
+
+    def test_file_browser_lists_directory_entries(self):
+        response = self.get(f"/setup/api/files/list?path={self.data}")
+
+        self.assertEqual(response.status_code, 200)
+        entries = {entry["name"]: entry for entry in response.json()["entries"]}
+        self.assertEqual(entries["nested"]["type"], "directory")
+        self.assertEqual(entries["notes.txt"]["type"], "file")
+        self.assertEqual(entries["notes.txt"]["path"], str(self.data / "notes.txt"))
+
+    def test_file_browser_error_responses_still_include_docs_links(self):
+        response = self.get(f"/setup/api/files/list?path={self.root / 'missing'}")
+
+        self.assertEqual(response.status_code, 404)
+        body = response.json()
+        self.assertIn("docs", body)
+        self.assertEqual(body["default_path"], "/data")
+
+    def test_file_preview_returns_text_content(self):
+        response = self.get(f"/setup/api/files/preview?path={self.data / 'notes.txt'}")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["path"], str(self.data / "notes.txt"))
+        self.assertEqual(body["content"], "hello from hermes\n")
+        self.assertFalse(body["truncated"])
+
+    def test_file_preview_rejects_directories(self):
+        response = self.get(f"/setup/api/files/preview?path={self.data / 'nested'}")
+
+        self.assertEqual(response.status_code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_file_browser_ui.py
+++ b/tests/test_file_browser_ui.py
@@ -1,0 +1,22 @@
+import unittest
+from pathlib import Path
+
+
+TEMPLATE_SOURCE = Path(__file__).resolve().parents[1] / "templates" / "index.html"
+
+
+class FileBrowserUiTest(unittest.TestCase):
+    def test_admin_template_exposes_file_browser_panel_without_replacing_dayshift_shell(self):
+        html = TEMPLATE_SOURCE.read_text()
+
+        self.assertIn("Dayshift Systems", html)
+        self.assertIn("page==='files'", html)
+        self.assertIn(">Files<", html)
+        self.assertIn("/setup/api/files/list", html)
+        self.assertIn("/setup/api/files/preview", html)
+        self.assertIn("/setup/api/files/download", html)
+        self.assertIn("Official Hermes Docker examples often use", html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -1,0 +1,85 @@
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from starlette.responses import JSONResponse
+from starlette.testclient import TestClient
+
+import server
+
+
+class EmptyAsyncStdout:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class FakeProc:
+    def __init__(self, pid: int, returncode: int | None = None):
+        self.pid = pid
+        self.returncode = returncode
+        self.stdout = EmptyAsyncStdout()
+
+
+class GatewaySyncTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.client = TestClient(server.app)
+        self.client.cookies.set(server.COOKIE_NAME, server._make_auth_token())
+
+    def test_native_dashboard_restart_uses_wrapper_gateway_manager(self):
+        proxied = JSONResponse({"proxied": True}, status_code=599)
+
+        with (
+            patch.object(server.gw, "restart", new=AsyncMock()) as restart,
+            patch.object(server, "_proxy_to_dashboard", new=AsyncMock(return_value=proxied)) as proxy,
+        ):
+            response = self.client.post("/api/gateway/restart")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"ok": True, "name": "gateway-restart"})
+        restart.assert_called_once()
+        proxy.assert_not_called()
+
+    async def test_old_gateway_drain_does_not_mark_new_process_as_error(self):
+        gateway = server.Gateway()
+        old_proc = FakeProc(pid=100, returncode=0)
+        new_proc = FakeProc(pid=200, returncode=None)
+
+        gateway.proc = new_proc
+        gateway.state = "running"
+
+        await gateway._drain(old_proc)
+
+        self.assertIs(gateway.proc, new_proc)
+        self.assertEqual(gateway.state, "running")
+        self.assertEqual(list(gateway.logs), [])
+
+    async def test_start_adopts_existing_gateway_pid_instead_of_spawning_duplicate(self):
+        sleep_proc = await asyncio.create_subprocess_exec("sleep", "30")
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                pid_file = Path(tmp) / "gateway.pid"
+                pid_file.write_text(str(sleep_proc.pid))
+                gateway = server.Gateway()
+
+                with (
+                    patch.object(server, "GATEWAY_PID_FILE", pid_file),
+                    patch("server.asyncio.create_subprocess_exec", new=AsyncMock()) as spawn,
+                ):
+                    await gateway.start()
+                    status = gateway.status()
+
+            spawn.assert_not_called()
+            self.assertEqual(status["state"], "running")
+            self.assertEqual(status["pid"], sleep_proc.pid)
+        finally:
+            sleep_proc.terminate()
+            await sleep_proc.wait()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_login_page.py
+++ b/tests/test_login_page.py
@@ -1,0 +1,40 @@
+import unittest
+from pathlib import Path
+
+
+SERVER_SOURCE = Path(__file__).resolve().parents[1] / "server.py"
+
+
+def login_template_source() -> str:
+    source = SERVER_SOURCE.read_text()
+    start = source.index('LOGIN_PAGE_HTML = """')
+    end = source.index('"""\n\n\ndef _html_escape', start)
+    return source[start:end]
+
+
+class LoginPageDesignTest(unittest.TestCase):
+    def test_login_template_uses_dayshift_design_system_tokens(self):
+        html = login_template_source()
+
+        self.assertIn("Inter Tight", html)
+        self.assertIn("JetBrains Mono", html)
+        self.assertIn("--ds-bg: #10100E", html)
+        self.assertIn("--ds-primary: #FFFFE3", html)
+        self.assertIn("--ds-accent: #7A9E90", html)
+        self.assertIn("WELCOME BACK", html)
+        self.assertIn("hermes", html)
+
+    def test_login_template_preserves_auth_form_contract(self):
+        html = login_template_source()
+
+        self.assertIn('method="POST"', html)
+        self.assertIn('action="/login"', html)
+        self.assertIn('name="returnTo"', html)
+        self.assertIn("__RETURN_TO__", html)
+        self.assertIn("__ERROR__", html)
+        self.assertIn('autocomplete="username"', html)
+        self.assertIn('autocomplete="current-password"', html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setup_template.py
+++ b/tests/test_setup_template.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import unittest
+
+
+TEMPLATE = Path(__file__).resolve().parents[1] / "templates" / "index.html"
+
+
+def read_template() -> str:
+    return TEMPLATE.read_text()
+
+
+class SetupTemplateTest(unittest.TestCase):
+    def test_sidebar_monitor_items_are_not_setup_locked(self):
+        html = read_template()
+
+        self.assertNotIn("locked: !isSetupDone", html)
+        self.assertNotIn("isSetupDone && (page='status')", html)
+        self.assertNotIn("isSetupDone && (page='logs')", html)
+        self.assertNotIn("isSetupDone && (page='users')", html)
+
+    def test_openrouter_does_not_require_model_field_in_setup(self):
+        html = read_template()
+
+        self.assertIn('x-show="selectedProvider && selectedProvider !== \'OpenRouter\'"', html)
+        self.assertNotIn("OpenRouter format:", html)
+        self.assertNotIn("LLM Provider\n          <span class=\"req-note\">— required</span>", html)
+        self.assertNotIn("LLM Model</label>", html)


### PR DESCRIPTION
Background

The template exposes two control surfaces for the Hermes gateway: the wrapper setup dashboard under /setup, and the proxied native Hermes dashboard under /. The setup dashboard owns a Gateway subprocess manager, but the native dashboard also exposes its own gateway start/stop/restart routes. When a user restarted the gateway from inside the native Hermes dashboard, that request could spawn or restart a gateway outside the wrapper’s tracked subprocess state.

After returning to the setup dashboard, the wrapper still believed it needed to start/manage its own gateway process. Hermes then detected the existing gateway.pid and exited with:

Gateway already running (PID ...)
Use 'hermes gateway restart' to replace it
This made the two dashboards drift out of sync.

What Changed

Added gateway.pid awareness to the wrapper’s Gateway manager.
If a gateway PID already exists and is live, the wrapper now adopts that state instead of spawning a duplicate.
Stop/restart can now terminate an externally-started gateway PID before starting a wrapper-managed process.
Intercepted native dashboard gateway routes:
/api/gateway/start
/api/gateway/stop
/api/gateway/restart
/api/actions/gateway-restart/status
These routes now use the wrapper’s gateway manager instead of being proxied through to Hermes’ separate action runner.
Fixed a restart race where an old stdout drain task could mark the newly-started gateway as errored.
Added regression tests for native dashboard restart routing, PID adoption, and stale drain behavior.
Test Plan

.venv/bin/python -m unittest discover -s tests