### PR TITLE
fix: run Railway start command through tini

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "dockerfile"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "/app/start.sh"
+startCommand = "/usr/bin/tini -g -- /app/start.sh"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "on_failure"


### PR DESCRIPTION
## Summary
- change Railway deploy startCommand to run through /usr/bin/tini
- preserve the existing /app/start.sh startup path

## Why
The Dockerfile already installs tini as the intended init process, but railway.toml currently sets startCommand to /app/start.sh. For Railway Dockerfile deployments, that start command can bypass the image ENTRYPOINT, causing python /app/server.py to become PID 1. In long-running Hermes deployments, exited child processes can then remain as zombies and consume the cgroup PID limit.

## Verification
- One-line config-only change
- Expected runtime check after deployment: /proc/1/cmdline should show /usr/bin/tini -g -- /app/start.sh