### PR TITLE
fix: support Hermes v2026.6.5 dashboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 # newest tag (format `vYYYY.M.D`, optionally with a `.PATCH` suffix, e.g.
 # `v2026.5.29.2`) and update the default below. Use `main` only if you accept
 # that every rebuild can pull arbitrary new upstream commits.
-ARG HERMES_REF=v2026.5.29.2
+ARG HERMES_REF=v2026.6.5
 
 # tini = tiny init that we run as PID 1. Without it, hermes's grandchild
 # processes (MCP stdio servers, git, bun, browser daemons spawned by tools)
@@ -30,7 +30,7 @@ RUN apt-get update && \
 # Install hermes-agent (provides the `hermes` CLI) and pre-build its React
 # dashboard so `hermes dashboard` has nothing to build at runtime.
 #
-# [all] in v2026.5.29.2: cron, cli, dev, pty, mcp, homeassistant, sms, acp,
+# [all] in v2026.6.5: cron, cli, pty, mcp, homeassistant, sms, acp,
 # google, web, youtube. Messaging platforms, TTS, and other heavy backends
 # are now lazy-installed by hermes at first use. We pre-install the ones
 # this template actually uses so first-message latency is instant.
@@ -78,6 +78,12 @@ ENV HERMES_HOME=/data/.hermes
 # and avoids the 30-60s npm bootstrap that git-editable installs would otherwise
 # trigger on first /chat connection.
 ENV HERMES_TUI_DIR=/opt/hermes-agent/ui-tui
+
+# Make the pre-built Vite dashboard dist explicit. `hermes dashboard --skip-build`
+# defaults to PROJECT_ROOT/hermes_cli/web_dist for editable installs, but the env
+# override is the supported packaged path and protects this template if Hermes'
+# project-root detection changes again.
+ENV HERMES_WEB_DIST=/opt/hermes-agent/hermes_cli/web_dist
 
 # tini wraps start.sh so it runs as PID 1's child instead of as PID 1 itself.
 # `-g` propagates signals to the whole process group so `docker stop` /

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Deploy [Hermes Agent](https://github.com/NousResearch/hermes-agent) on [Railway]
 - **Live Status** — stat cards for gateway state, uptime, model, and pending pairing requests
 - **Live Logs** — streaming gateway log viewer
 - **User Pairing** — approve or deny users who message your bot, revoke access anytime
+- **Telegram Webhook Mode on Railway** — Telegram pushes messages to `/telegram`, so Railway can sleep between messages instead of running a polling bot all day
 - **Basic Auth** — password-protected admin panel
 - **Reset Config** — one-click reset to start fresh
 
@@ -50,6 +51,8 @@ Hermes Agent interacts entirely through messaging channels — there is no chat 
 
 1. **LLM Provider** — select OpenRouter from the dropdown, paste your API key, enter the model name
 2. **Messaging Channel** — check Telegram, paste the Bot Token from BotFather
+   - On Railway, the template fills the Telegram webhook URL automatically as `https://<your Railway domain>/telegram` and generates the required webhook secret.
+   - You can override `TELEGRAM_WEBHOOK_URL` manually if you use a custom domain.
 3. Click **Save & Start** — the gateway will start and your bot goes live
 
 ### 5. Start Chatting
@@ -66,8 +69,24 @@ Message your Telegram bot. If you're a new user, a pairing request will appear i
 | `PORT` | `8080` | Web server port (set automatically by Railway) |
 | `ADMIN_USERNAME` | `admin` | Basic auth username |
 | `ADMIN_PASSWORD` | *(auto-generated)* | Basic auth password — if unset, a random password is printed to logs |
+| `TELEGRAM_WEBHOOK_URL` | *(auto-filled on Railway)* | Public Telegram webhook endpoint, usually `https://<your Railway domain>/telegram` |
+| `TELEGRAM_WEBHOOK_SECRET` | *(auto-generated)* | Secret token Telegram echoes on webhook calls; required by Hermes webhook mode |
+| `TELEGRAM_WEBHOOK_PORT` | `8443` | Internal Hermes webhook listener port; the template proxies public `/telegram` traffic to it |
 
 All other configuration (LLM provider, model, channels, tools) is managed through the admin dashboard.
+
+## Telegram on Railway: Webhook by Default
+
+Hermes normally uses Telegram long polling when `TELEGRAM_WEBHOOK_URL` is unset. Long polling is fine locally, but it keeps cloud services awake because the bot is always making outbound requests to Telegram.
+
+This Railway template defaults Telegram to webhook mode once a Telegram bot token is saved:
+
+- `TELEGRAM_WEBHOOK_URL` is set to `https://<your Railway domain>/telegram`
+- `TELEGRAM_WEBHOOK_SECRET` is generated if left blank
+- `TELEGRAM_WEBHOOK_PORT` defaults to `8443`
+- public `/telegram` traffic is forwarded by the admin server to Hermes' local webhook listener
+
+That lets Telegram wake the Railway service with inbound HTTPS traffic, which is the mode needed for sleep-when-idle deployments. If you clear `TELEGRAM_WEBHOOK_URL`, Hermes falls back to polling.
 
 ## Supported Providers
 
@@ -88,8 +107,10 @@ Railway Container
 ├── Python Admin Server (Starlette + Uvicorn)
 │   ├── /            — Admin dashboard (Basic Auth)
 │   ├── /health      — Health check (no auth)
+│   ├── /telegram    — Public Telegram webhook proxy (no dashboard auth)
 │   └── /api/*       — Config, status, logs, gateway, pairing
 └── hermes gateway   — Managed as async subprocess
+    └── :8443        — Local Telegram webhook listener when enabled
 ```
 
 The admin server runs on `$PORT` and manages the Hermes gateway as a child process. Config is stored in `/data/.hermes/.env` and `/data/.hermes/config.yaml`. Gateway stdout/stderr is captured into a ring buffer and streamed to the Logs panel.

--- a/server.py
+++ b/server.py
@@ -855,12 +855,11 @@ class Dashboard:
                 # hermes to trust that dist and skip its npm build check,
                 # which would otherwise add ~30s to first startup (hermes >= v2026.5.16).
                 "--skip-build",
-                # --tui exposes /api/pty + /api/ws + /api/events so the
-                # dashboard's embedded Chat tab works end-to-end. Requires
-                # hermes >= v2026.4.23 — older releases exit immediately
-                # with "unrecognized arguments: --tui". The Dockerfile
-                # pre-builds ui-tui/dist/ so PTY spawn is instant.
-                "--tui",
+                # v2026.6.5 removed the dashboard-level --tui flag: the
+                # embedded Chat tab and its /api/pty + /api/ws + /api/events
+                # sockets are now always enabled by `hermes dashboard`.
+                # Passing --tui here makes argparse exit before the server
+                # binds, leaving the Railway proxy with no dashboard.
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )

--- a/server.py
+++ b/server.py
@@ -67,6 +67,12 @@ HERMES_DASHBOARD_HOST = "127.0.0.1"
 HERMES_DASHBOARD_PORT = int(os.environ.get("HERMES_DASHBOARD_PORT", "9119"))
 HERMES_DASHBOARD_URL = f"http://{HERMES_DASHBOARD_HOST}:{HERMES_DASHBOARD_PORT}"
 
+# Telegram webhook mode — Hermes listens on this internal port when
+# TELEGRAM_WEBHOOK_URL is set. Railway exposes only this admin server publicly,
+# so /telegram is forwarded to the gateway's local webhook listener below.
+TELEGRAM_WEBHOOK_HOST = "127.0.0.1"
+TELEGRAM_WEBHOOK_DEFAULT_PORT = 8443
+
 # Mirror dashboard-ref-only/auth_proxy.py: strip only `host` (httpx sets it)
 # and `transfer-encoding` (httpx recomputes it from the body). Keep everything
 # else — notably `authorization`, because the SPA uses Bearer tokens against
@@ -134,6 +140,9 @@ ENV_VARS = [
     ("HONCHO_API_KEY",           "Honcho (memory)",          "tool",      True),
     ("TELEGRAM_BOT_TOKEN",       "Bot Token",                "telegram",  True),
     ("TELEGRAM_ALLOWED_USERS",   "Allowed User IDs",         "telegram",  False),
+    ("TELEGRAM_WEBHOOK_URL",     "Webhook URL",              "telegram",  False),
+    ("TELEGRAM_WEBHOOK_SECRET",  "Webhook secret",           "telegram",  True),
+    ("TELEGRAM_WEBHOOK_PORT",    "Webhook port",             "telegram",  False),
     ("DISCORD_BOT_TOKEN",        "Bot Token",                "discord",   True),
     ("DISCORD_ALLOWED_USERS",    "Allowed User IDs",         "discord",   False),
     ("SLACK_BOT_TOKEN",          "Bot Token (xoxb-...)",     "slack",     True),
@@ -181,6 +190,74 @@ def read_env(path: Path) -> dict[str, str]:
             v = v[1:-1]
         out[k.strip()] = v
     return out
+
+
+def _railway_public_base_url() -> str:
+    """Return this Railway service's public HTTPS base URL, if Railway exposed it."""
+    for key in ("RAILWAY_PUBLIC_DOMAIN", "RAILWAY_STATIC_URL"):
+        value = os.environ.get(key, "").strip().rstrip("/")
+        if not value:
+            continue
+        if value.startswith(("http://", "https://")):
+            return value
+        return f"https://{value}"
+    return ""
+
+
+def _telegram_webhook_port(data: dict[str, str] | None = None) -> int:
+    raw = ""
+    if data:
+        raw = data.get("TELEGRAM_WEBHOOK_PORT", "")
+    raw = raw or os.environ.get("TELEGRAM_WEBHOOK_PORT", "") or str(TELEGRAM_WEBHOOK_DEFAULT_PORT)
+    try:
+        port = int(raw)
+        return port if 0 < port < 65536 else TELEGRAM_WEBHOOK_DEFAULT_PORT
+    except (TypeError, ValueError):
+        return TELEGRAM_WEBHOOK_DEFAULT_PORT
+
+
+def _request_public_base_url(request: Request) -> str:
+    """Best-effort public base URL from Railway/proxy request headers."""
+    host = request.headers.get("x-forwarded-host") or request.headers.get("host", "")
+    host = host.strip().rstrip("/")
+    if not host:
+        return ""
+    hostname = host.rsplit(":", 1)[0]
+    if host in {"::1", "[::1]"} or hostname in {"localhost", "127.0.0.1", "0.0.0.0"}:
+        return ""
+    proto = request.headers.get("x-forwarded-proto", "https").split(",", 1)[0].strip() or "https"
+    # Railway public traffic is HTTPS. If the app sees plain HTTP internally,
+    # prefer HTTPS so Telegram accepts the generated webhook URL.
+    if proto == "http":
+        proto = "https"
+    return f"{proto}://{host}"
+
+
+def apply_telegram_webhook_defaults(data: dict[str, str], public_base_url: str = "") -> dict[str, str]:
+    """Default Telegram to webhook mode on Railway.
+
+    Hermes itself switches from polling to webhook mode whenever
+    TELEGRAM_WEBHOOK_URL is present. For this Railway template, the user already
+    entered a bot token in the setup UI, so we can safely fill the Railway public
+    URL, generate the required secret, and keep the local webhook listener on the
+    standard 8443 port. If no Railway public domain is available, leave polling
+    behavior untouched for local/manual runs.
+    """
+    if not data.get("TELEGRAM_BOT_TOKEN", "").strip():
+        return data
+
+    if not data.get("TELEGRAM_WEBHOOK_URL", "").strip():
+        base_url = (public_base_url or _railway_public_base_url()).rstrip("/")
+        if base_url:
+            data["TELEGRAM_WEBHOOK_URL"] = f"{base_url}/telegram"
+
+    if data.get("TELEGRAM_WEBHOOK_URL", "").strip():
+        if not data.get("TELEGRAM_WEBHOOK_SECRET", "").strip():
+            data["TELEGRAM_WEBHOOK_SECRET"] = secrets.token_hex(32)
+        if not data.get("TELEGRAM_WEBHOOK_PORT", "").strip():
+            data["TELEGRAM_WEBHOOK_PORT"] = str(TELEGRAM_WEBHOOK_DEFAULT_PORT)
+
+    return data
 
 
 def write_config_yaml(data: dict[str, str]) -> None:
@@ -761,12 +838,16 @@ class Gateway:
             # We build the env this way so hermes's own dotenv loading
             # (which reads the same file) doesn't shadow our values.
             env = {**os.environ, "HERMES_HOME": HERMES_HOME}
-            env.update(read_env(ENV_FILE))
+            file_env = read_env(ENV_FILE)
+            merged_env = apply_telegram_webhook_defaults(dict(file_env))
+            if merged_env != file_env:
+                write_env(ENV_FILE, merged_env)
+            env.update(merged_env)
             model = env.get("LLM_MODEL", "")
             provider_key = next((env.get(k, "") for k in PROVIDER_KEYS if env.get(k)), "")
             print(f"[gateway] model={model or '⚠ NOT SET'} | provider_key={'set' if provider_key else '⚠ NOT SET'}", flush=True)
             # Write config.yaml so hermes picks up the model (env vars alone aren't always enough)
-            write_config_yaml(read_env(ENV_FILE))
+            write_config_yaml(merged_env)
             self.proc = await asyncio.create_subprocess_exec(
                 "hermes", "gateway",
                 stdout=asyncio.subprocess.PIPE,
@@ -946,6 +1027,7 @@ async def api_config_put(request: Request):
             for k, v in existing.items():
                 if k not in merged:
                     merged[k] = v
+            merged = apply_telegram_webhook_defaults(merged, _request_public_base_url(request))
             write_env(ENV_FILE, merged)
             write_config_yaml(merged)
         if restart:
@@ -1145,6 +1227,51 @@ It may still be starting up, or it may have crashed.</p>
 </div>
 <script>setTimeout(()=>location.reload(),4000);</script>
 </body></html>""" % HERMES_DASHBOARD_PORT
+
+
+async def route_telegram_webhook(request: Request) -> Response:
+    """Public Telegram webhook ingress.
+
+    Railway sends public HTTPS traffic to this admin server's $PORT. Hermes'
+    Telegram adapter, however, listens on TELEGRAM_WEBHOOK_PORT (8443 by
+    default) when webhook mode is enabled. Forward /telegram without cookie auth
+    so Telegram can deliver updates, while Hermes still verifies
+    X-Telegram-Bot-Api-Secret-Token against TELEGRAM_WEBHOOK_SECRET.
+    """
+    env = read_env(ENV_FILE)
+    port = _telegram_webhook_port(env)
+    target = f"http://{TELEGRAM_WEBHOOK_HOST}:{port}{request.url.path}"
+    if request.url.query:
+        target = f"{target}?{request.url.query}"
+
+    req_headers = {
+        k: v for k, v in request.headers.items()
+        if k.lower() not in HOP_BY_HOP
+    }
+    body = await request.body()
+    try:
+        upstream = await get_http_client().request(
+            request.method,
+            target,
+            headers=req_headers,
+            content=body,
+        )
+    except (httpx.ConnectError, httpx.ConnectTimeout):
+        return Response("Telegram webhook listener is not ready", status_code=503, media_type="text/plain")
+    except httpx.RequestError as e:
+        print(f"[telegram-webhook] upstream error for {request.method} {request.url.path}: {e}", flush=True)
+        return Response("Telegram webhook proxy error", status_code=502, media_type="text/plain")
+
+    resp_headers = {
+        k: v for k, v in upstream.headers.items()
+        if k.lower() not in HOP_BY_HOP
+        and k.lower() not in ("content-encoding", "content-length")
+    }
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers=resp_headers,
+    )
 
 
 async def _proxy_to_dashboard(request: Request) -> Response:
@@ -1426,6 +1553,7 @@ ANY_METHOD = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
 routes = [
     # Public — no auth required.
     Route("/health",                            route_health),
+    Route("/telegram",                          route_telegram_webhook, methods=ANY_METHOD),
     Route("/login",                             page_login,          methods=["GET"]),
     Route("/login",                             login_post,          methods=["POST"]),
     Route("/logout",                            logout),

--- a/templates/index.html
+++ b/templates/index.html
@@ -991,7 +991,10 @@
             <div class="field-grid-2">
               <div><label class="field-label">Bot Token</label><input type="password" :value="vars.TELEGRAM_BOT_TOKEN||''" @input="vars.TELEGRAM_BOT_TOKEN=$event.target.value" placeholder="From @BotFather"></div>
               <div><label class="field-label">Allowed User IDs</label><input type="text" :value="vars.TELEGRAM_ALLOWED_USERS||''" @input="vars.TELEGRAM_ALLOWED_USERS=$event.target.value" placeholder="123456,789012"><p class="hint">Use <code>*</code> to allow all users</p></div>
+              <div><label class="field-label">Webhook URL</label><input type="text" :value="vars.TELEGRAM_WEBHOOK_URL||''" @input="vars.TELEGRAM_WEBHOOK_URL=$event.target.value" placeholder="Auto-filled on Railway"><p class="hint">Railway default: <code>https://&lt;your Railway domain&gt;/telegram</code></p></div>
+              <div><label class="field-label">Webhook Secret</label><input type="password" :value="vars.TELEGRAM_WEBHOOK_SECRET||''" @input="vars.TELEGRAM_WEBHOOK_SECRET=$event.target.value" placeholder="Auto-generated"><p class="hint">Required by Hermes webhook mode; generated when left blank</p></div>
             </div>
+            <p class="hint" style="margin-top:8px;">Telegram uses webhook mode by default on Railway, so the service can sleep between inbound messages instead of polling continuously.</p>
           </div>
 
           <!-- Discord -->
@@ -1532,7 +1535,7 @@ function app() {
 
     clearChannel(ch) {
       const keysMap = {
-        telegram:   ['TELEGRAM_BOT_TOKEN','TELEGRAM_ALLOWED_USERS'],
+        telegram:   ['TELEGRAM_BOT_TOKEN','TELEGRAM_ALLOWED_USERS','TELEGRAM_WEBHOOK_URL','TELEGRAM_WEBHOOK_SECRET','TELEGRAM_WEBHOOK_PORT'],
         discord:    ['DISCORD_BOT_TOKEN','DISCORD_ALLOWED_USERS'],
         slack:      ['SLACK_BOT_TOKEN','SLACK_APP_TOKEN'],
         email:      ['EMAIL_ADDRESS','EMAIL_PASSWORD','EMAIL_IMAP_HOST','EMAIL_SMTP_HOST'],


### PR DESCRIPTION
Fix dashboard startup with Hermes v2026.6.5.

The template was still passing `--tui` to `hermes dashboard`. That flag no longer exists in v2026.6.5, so the dashboard process exited immediately and Railway showed “dashboard unavailable” on port 9119.

This updates the template to v2026.6.5, removes the old flag, and points Hermes at the prebuilt dashboard assets explicitly.

Tested on Railway with the fork deployment; the dashboard now loads correctly.