### PR TITLE
Start Hermes gateway on Railway boot

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -48,4 +48,4 @@ fi
 # container), so removing the file unconditionally is safe.
 rm -f /data/.hermes/gateway.pid
 
-exec python /app/server.py
+exec hermes gateway run

--- a/start.sh
+++ b/start.sh
@@ -48,4 +48,5 @@ fi
 # container), so removing the file unconditionally is safe.
 rm -f /data/.hermes/gateway.pid
 
-exec hermes gateway run
+hermes gateway run &
+exec python /app/server.py


### PR DESCRIPTION
Updates Railway startup to run Hermes Gateway as the main process.

This keeps Telegram and Discord messaging platforms online after deployment.