### PR TITLE
feat: bootstrap Google OAuth credentials, GBrain token, memories and skills from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,46 @@ Message your Telegram bot. If you're a new user, a pairing request will appear i
 
 All other configuration (LLM provider, model, channels, tools) is managed through the admin dashboard.
 
+## Bootstrapping Credentials
+
+When migrating a local Hermes setup to Railway, you can seed credentials, memories, and skills via environment variables. Each is written **only once** — if the target file already exists on the persistent volume, it won't be overwritten on redeploy.
+
+### Generate the env vars (run on your local Mac)
+
+```bash
+# 1. Hermes auth.json (xAI / SuperGrok OAuth tokens)
+#    Already supported — just set the raw JSON as the value.
+export HERMES_AUTH_JSON_BOOTSTRAP=$(cat ~/.hermes/auth.json)
+
+# 2. Google OAuth credentials (base64-encoded)
+export HERMES_GOOGLE_TOKEN_JSON=$(cat ~/.hermes/google_token.json | base64)
+export HERMES_GOOGLE_CLIENT_SECRET_JSON=$(cat ~/.hermes/google_client_secret.json | base64)
+
+# 3. GBrain bearer token (plain text)
+export HERMES_GBRAIN_TOKEN=$(cat ~/.config/gbrain/token)
+
+# 4. Hermes memories (base64-encoded)
+export HERMES_MEMORY_MD=$(cat ~/.hermes/memories/MEMORY.md | base64)
+export HERMES_USER_MD=$(cat ~/.hermes/memories/USER.md | base64)
+
+# 5. Custom skills (base64-encoded tar.gz archive)
+export HERMES_SKILLS_TARGZ=$(tar -czf - -C ~/.hermes/skills . | base64)
+```
+
+Then set each as a **Railway service variable** on the Hermes Agent service (Settings → Variables, or `railway variables set`).
+
+| Variable | Format | Written to | Overwrite? |
+|----------|--------|-----------|------------|
+| `HERMES_AUTH_JSON_BOOTSTRAP` | Raw JSON | `/data/.hermes/auth.json` | Once (skip if exists) |
+| `HERMES_GOOGLE_TOKEN_JSON` | Base64 | `/data/.hermes/google_token.json` | Once (skip if exists) |
+| `HERMES_GOOGLE_CLIENT_SECRET_JSON` | Base64 | `/data/.hermes/google_client_secret.json` | Once (skip if exists) |
+| `HERMES_GBRAIN_TOKEN` | Plain text | `/data/.config/gbrain/token` + `/data/.hermes/.gbrain_token` | Every boot |
+| `HERMES_MEMORY_MD` | Base64 | `/data/.hermes/memories/MEMORY.md` | Once (skip if exists) |
+| `HERMES_USER_MD` | Base64 | `/data/.hermes/memories/USER.md` | Once (skip if exists) |
+| `HERMES_SKILLS_TARGZ` | Base64 tar.gz | `/data/.hermes/skills/` | Once (skip if dir non-empty) |
+
+> **Tip:** To force re-seeding a file, delete it from the Railway volume (e.g. via `railway shell` → `rm /data/.hermes/google_token.json`) and redeploy.
+
 ## Supported Providers
 
 OpenRouter, DeepSeek, DashScope, GLM / Z.AI, Kimi, MiniMax, HuggingFace

--- a/start.sh
+++ b/start.sh
@@ -39,6 +39,55 @@ if [ ! -f /data/.hermes/auth.json ] && [ -n "${HERMES_AUTH_JSON_BOOTSTRAP}" ]; t
   chmod 600 /data/.hermes/auth.json
 fi
 
+# Bootstrap Google OAuth credentials from env vars.
+# Export your local credentials:
+#   HERMES_GOOGLE_TOKEN_JSON=$(cat ~/.hermes/google_token.json | base64)
+#   HERMES_GOOGLE_CLIENT_SECRET_JSON=$(cat ~/.hermes/google_client_secret.json | base64)
+# Set these as Railway env vars on the Hermes Agent service.
+# Written only once — if the file exists on the volume, it won't be overwritten.
+if [ ! -f /data/.hermes/google_token.json ] && [ -n "${HERMES_GOOGLE_TOKEN_JSON}" ]; then
+  printf '%s' "${HERMES_GOOGLE_TOKEN_JSON}" | base64 -d > /data/.hermes/google_token.json
+  chmod 600 /data/.hermes/google_token.json
+fi
+if [ ! -f /data/.hermes/google_client_secret.json ] && [ -n "${HERMES_GOOGLE_CLIENT_SECRET_JSON}" ]; then
+  printf '%s' "${HERMES_GOOGLE_CLIENT_SECRET_JSON}" | base64 -d > /data/.hermes/google_client_secret.json
+  chmod 600 /data/.hermes/google_client_secret.json
+fi
+
+# Bootstrap GBrain bearer token from env var.
+# Get your token from ~/.config/gbrain/token on your local machine.
+# Set HERMES_GBRAIN_TOKEN as a Railway env var.
+# Stored in two locations for compatibility with different script patterns.
+if [ -n "${HERMES_GBRAIN_TOKEN}" ]; then
+  mkdir -p /data/.config/gbrain
+  printf '%s' "${HERMES_GBRAIN_TOKEN}" > /data/.config/gbrain/token
+  chmod 600 /data/.config/gbrain/token
+  # Also write to .hermes home for scripts that use HERMES_HOME
+  printf '%s' "${HERMES_GBRAIN_TOKEN}" > /data/.hermes/.gbrain_token
+  chmod 600 /data/.hermes/.gbrain_token
+fi
+
+# Bootstrap Hermes memories from env vars.
+# Export your local memories:
+#   HERMES_MEMORY_MD=$(cat ~/.hermes/memories/MEMORY.md | base64)
+#   HERMES_USER_MD=$(cat ~/.hermes/memories/USER.md | base64)
+# Written only once — manual edits made in Railway won't be overwritten on redeploy.
+if [ ! -f /data/.hermes/memories/MEMORY.md ] && [ -n "${HERMES_MEMORY_MD}" ]; then
+  printf '%s' "${HERMES_MEMORY_MD}" | base64 -d > /data/.hermes/memories/MEMORY.md
+fi
+if [ ! -f /data/.hermes/memories/USER.md ] && [ -n "${HERMES_USER_MD}" ]; then
+  printf '%s' "${HERMES_USER_MD}" | base64 -d > /data/.hermes/memories/USER.md
+fi
+
+# Bootstrap custom skills from env var (base64-encoded tar.gz).
+# Export your local skills:
+#   HERMES_SKILLS_TARGZ=$(tar -czf - -C ~/.hermes/skills . | base64)
+# Set HERMES_SKILLS_TARGZ as a Railway env var.
+# Only runs if skills directory is empty (no existing skills).
+if [ -z "$(ls -A /data/.hermes/skills 2>/dev/null)" ] && [ -n "${HERMES_SKILLS_TARGZ}" ]; then
+  printf '%s' "${HERMES_SKILLS_TARGZ}" | base64 -d | tar -xzf - -C /data/.hermes/skills
+fi
+
 # Clear any stale gateway PID file left over from the previous container.
 # `hermes gateway` writes /data/.hermes/gateway.pid on start but does not
 # remove it on SIGTERM. Since /data is a persistent volume, the file


### PR DESCRIPTION
Adds env-var-based bootstrap support for migrating a local Hermes setup to Railway. New `start.sh` blocks seed credentials from environment variables on first boot (write-once, skip if file exists on volume).

## New environment variables

| Variable | Format | Destination |
|----------|--------|-------------|
| `HERMES_GOOGLE_TOKEN_JSON` | Base64 | `/data/.hermes/google_token.json` |
| `HERMES_GOOGLE_CLIENT_SECRET_JSON` | Base64 | `/data/.hermes/google_client_secret.json` |
| `HERMES_GBRAIN_TOKEN` | Plain text | `/data/.config/gbrain/token` + `/data/.hermes/.gbrain_token` |
| `HERMES_MEMORY_MD` | Base64 | `/data/.hermes/memories/MEMORY.md` |
| `HERMES_USER_MD` | Base64 | `/data/.hermes/memories/USER.md` |
| `HERMES_SKILLS_TARGZ` | Base64 tar.gz | `/data/.hermes/skills/` |

## Use case

When running Hermes locally you accumulate OAuth tokens (Google Calendar/Gmail), GBrain bearer tokens, memory files, and custom skills. This PR lets you export all of those as env vars and set them on the Railway service so your cloud Hermes instance starts with the same capabilities as your local one — no manual file copying needed.

All bootstrap blocks follow the same pattern as the existing `HERMES_AUTH_JSON_BOOTSTRAP`: write-once on first boot, skip if the file already exists on the persistent volume.

README updated with a new "Bootstrapping Credentials" section documenting exact copy-paste commands.