### PR TITLE
feat: support multiple profile gateways via HERMES_EXTRA_PROFILES

### DIFF
--- a/server.py
+++ b/server.py
@@ -759,7 +759,8 @@ RESPAWN_MAX_DELAY  = 30.0    # backoff cap
 
 
 class Gateway:
-    def __init__(self):
+    def __init__(self, profile: str | None = None):
+        self.profile = profile
         self.proc: asyncio.subprocess.Process | None = None
         self.state = "stopped"
         self.logs: deque[str] = deque(maxlen=500)
@@ -793,8 +794,12 @@ class Gateway:
             print(f"[gateway] model={model or '⚠ NOT SET'} | provider_key={'set' if provider_key else '⚠ NOT SET'}", flush=True)
             # Write config.yaml so hermes picks up the model (env vars alone aren't always enough)
             write_config_yaml(read_env(ENV_FILE))
+            cmd = ["hermes"]
+            if self.profile:
+                cmd += ["-p", self.profile]
+            cmd += ["gateway"]
             self.proc = await asyncio.create_subprocess_exec(
-                "hermes", "gateway",
+                *cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 env=env,
@@ -906,6 +911,11 @@ class Gateway:
 
 
 gw = Gateway()
+# Additional profile gateways — supervised by the same Railway admin server
+# so they survive container restarts alongside the default profile.
+# Set HERMES_EXTRA_PROFILES=eko,other to auto-start extra profile gateways.
+EXTRA_PROFILES = [p.strip() for p in os.environ.get("HERMES_EXTRA_PROFILES", "").split(",") if p.strip()]
+extra_gateways: list[Gateway] = [Gateway(profile=p) for p in EXTRA_PROFILES]
 cfg_lock = asyncio.Lock()
 
 
@@ -1338,6 +1348,16 @@ async def auto_start():
         asyncio.create_task(gw.start())
     else:
         print("[server] Config incomplete — gateway not started. Configure provider + model in the admin UI.", flush=True)
+    # Start additional profile gateways (e.g. eko) that have their own .env with
+    # credentials configured. These are supervised independently with the same
+    # crash-loop protection as the default profile.
+    for eg in extra_gateways:
+        profile_env = Path(HERMES_HOME) / "profiles" / eg.profile / ".env"
+        if profile_env.exists():
+            print(f"[server] Starting extra profile gateway: {eg.profile}", flush=True)
+            asyncio.create_task(eg.start())
+        else:
+            print(f"[server] Extra profile '{eg.profile}' has no .env — skipping", flush=True)
 
 
 @asynccontextmanager
@@ -1352,6 +1372,7 @@ async def lifespan(app):
         await asyncio.gather(
             gw.stop(),
             dash.stop(),
+            *[eg.stop() for eg in extra_gateways],
             return_exceptions=True,
         )
         global _http_client


### PR DESCRIPTION
## Problem

The Railway admin server (`server.py`) only supervises the **default** profile gateway. Additional profiles (e.g. `eko`) must be started manually with `hermes -p eko gateway run` and have no auto-restart on container restart or crash.

This means any second profile dies silently when:
- Railway redeploys the container
- The gateway process crashes
- SIGTERM hits during resource pressure

...and stays dead until someone manually restarts it.

## Solution

Parameterize the `Gateway` class with an optional `profile` name and read `HERMES_EXTRA_PROFILES` from the environment (comma-separated list of profile names).

### Changes to `server.py`

1. **`Gateway.__init__`** - accepts `profile: str | None = None`
2. **`Gateway.start`** - builds command as `hermes -p <profile> gateway` when profile is set, otherwise `hermes gateway` (unchanged default)
3. **Module level** - parses `HERMES_EXTRA_PROFILES` and creates `Gateway` instances for each
4. **`auto_start()`** - starts each extra profile gateway if its `~/.hermes/profiles/<name>/.env` exists
5. **`lifespan()` shutdown** - stops all extra gateways alongside the default

### Crash-loop protection

Extra profile gateways inherit the **same** crash-loop guard as the default (`RESPAWN_MAX_IN_WIN`, exponential backoff) because they use the same `Gateway` class.

### Usage

```
HERMES_EXTRA_PROFILES=eko
```

Each listed profile must have its own `.env` with platform credentials under `~/.hermes/profiles/<name>/.env`.

### Backward compatible

- If `HERMES_EXTRA_PROFILES` is unset or empty, behavior is identical to before.
- The default profile gateway is unchanged (no `-p` flag).

## Testing

Running this patch in production on Railway. Both gateways (default + eko) start on boot, survive crashes, and restart independently.