### PR TITLE
Add Lark/Feishu setup, pairing recovery, and port preflight

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,12 @@ GATEWAY_ALLOW_ALL_USERS=true
 # Options: local, docker, modal, ssh
 TERMINAL_ENV=local
 TERMINAL_TIMEOUT=60
+
+# ── Optional: Hermes API server ───────────────────────────────────────────────
+# Railway's public PORT belongs to the template web server (recommended: 8080).
+# Keep this optional internal API port distinct from PORT and from the native
+# dashboard port HERMES_DASHBOARD_PORT (default: 9119). Uncomment these only
+# when enabling the API in this persisted file; .env overrides Railway values.
+# API_SERVER_ENABLED=false
+# API_SERVER_PORT=8642
+# API_SERVER_KEY=

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Deploy [Hermes Agent](https://github.com/NousResearch/hermes-agent) on [Railway]
 - **Live Status** — stat cards for gateway state, uptime, model, and pending pairing requests
 - **Live Logs** — streaming gateway log viewer
 - **User Pairing** — approve or deny users who message your bot, revoke access anytime
-- **Basic Auth** — password-protected admin panel
+- **Admin Login** — cookie-authenticated, password-protected admin panel
 - **Reset Config** — one-click reset to start fresh
 
 ## Getting Started
@@ -44,7 +44,8 @@ Hermes Agent interacts entirely through messaging channels — there is no chat 
 1. Click the **Deploy on Railway** button above
 2. Set the `ADMIN_PASSWORD` environment variable (or a random one will be generated and printed to deploy logs)
 3. Attach a **volume** mounted at `/data` (persists config across redeploys)
-4. Open your app URL — log in with username `admin` and your password
+4. Keep the Railway public `PORT` on `8080`; do not reuse the internal dashboard/API ports
+5. Open your app URL — log in with username `admin` and your password
 
 ### 4. Configure in the Admin Dashboard
 
@@ -63,12 +64,39 @@ Message your Telegram bot. If you're a new user, a pairing request will appear i
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PORT` | `8080` | Web server port (set automatically by Railway) |
-| `ADMIN_USERNAME` | `admin` | Basic auth username |
-| `ADMIN_PASSWORD` | *(auto-generated)* | Basic auth password — if unset, a random password is printed to logs |
+| `PORT` | `8080` | Public Starlette web server port. Railway routes traffic here. Do not set it to `9119` or `8642`. |
+| `HERMES_DASHBOARD_PORT` | `9119` | Internal Hermes dashboard port, proxied through the public web server. |
+| `API_SERVER_ENABLED` | `false` | Enables Hermes' optional OpenAI-compatible API server. |
+| `API_SERVER_PORT` | `8642` | Internal Hermes API server port when enabled. Must differ from `PORT` and `HERMES_DASHBOARD_PORT`. |
+| `API_SERVER_KEY` | *(unset)* | Optional bearer key for the API server. A non-empty value also enables the API server. |
+| `ADMIN_USERNAME` | `admin` | Admin login username |
+| `ADMIN_PASSWORD` | *(auto-generated)* | Admin login password — if unset, a random password is printed to logs |
 | `HERMES_REF` | *(pinned in Dockerfile)* | Hermes Agent version to install (any upstream git tag/branch). Set this to override the Dockerfile default without editing code — see [Updating Hermes](#updating-hermes). |
 
-All other configuration (LLM provider, model, channels, tools) is managed through the admin dashboard.
+LLM provider, model, channel, and tool configuration is managed through the admin dashboard.
+
+### Port ownership and preflight
+
+All active listeners share one Railway container and must use distinct ports. The API port is reserved only when the optional API server is enabled (explicitly or by setting `API_SERVER_KEY`):
+
+| Listener | Recommended port | Exposure |
+|----------|------------------|----------|
+| Template web server (`PORT`) | `8080` | Public, through Railway |
+| Native Hermes dashboard (`HERMES_DASHBOARD_PORT`) | `9119` | Loopback only, reverse-proxied by the template |
+| Optional Hermes API server (`API_SERVER_PORT`) | `8642` | Internal unless you deliberately expose it |
+
+The template checks both the effective environment and persisted `config.yaml` before starting the gateway. It does **not** silently choose a new port. For an environment-enabled API server, it disables only the API adapter for that gateway start, keeps messaging channels running, and shows an actionable warning at the top of **Setup**. If `config.yaml` explicitly enables the conflicting API listener, the template blocks gateway start rather than mutating persistent configuration or entering a reconnect loop. Fix the conflicting port, then restart or redeploy.
+
+#### Troubleshooting: repeated `Reconnect api_server failed`
+
+If Railway logs repeatedly report `Reconnect api_server failed` or `address already in use`:
+
+1. Open **Railway → Service → Variables**.
+2. Set `PORT=8080`.
+3. Keep `HERMES_DASHBOARD_PORT=9119` and `API_SERVER_PORT=8642`, or choose other unused, distinct internal ports.
+4. Redeploy the service, then confirm the warning has disappeared from **Setup**.
+
+If API settings were previously saved into `/data/.hermes/.env`, update that persisted Hermes configuration as well: it takes precedence over Railway variables for child processes, so a stored `API_SERVER_PORT` can still create a collision.
 
 ## Supported Providers
 
@@ -86,11 +114,14 @@ Parallel (search), Firecrawl (scraping), Tavily (search), FAL (image gen), Brows
 
 ```
 Railway Container
-├── Python Admin Server (Starlette + Uvicorn)
-│   ├── /            — Admin dashboard (Basic Auth)
-│   ├── /health      — Health check (no auth)
-│   └── /api/*       — Config, status, logs, gateway, pairing
-└── hermes gateway   — Managed as async subprocess
+├── Python Admin Server (Starlette + Uvicorn) — 0.0.0.0:$PORT (public)
+│   ├── /setup       — Template setup/admin UI (cookie auth)
+│   ├── /setup/api/* — Config, status, logs, gateway, pairing
+│   ├── /health      — Railway health check (no auth)
+│   └── /*           — Reverse proxy to the native dashboard
+├── Native Hermes Dashboard — 127.0.0.1:9119 (internal)
+└── hermes gateway — managed as async subprocess
+    └── Optional API Server — 127.0.0.1:8642 (internal by default)
 ```
 
 The admin server runs on `$PORT` and manages the Hermes gateway as a child process. Config is stored in `/data/.hermes/.env` and `/data/.hermes/config.yaml`. Gateway stdout/stderr is captured into a ring buffer and streamed to the Logs panel.

--- a/server.py
+++ b/server.py
@@ -35,6 +35,7 @@ import re
 import secrets
 import signal
 import time
+from collections.abc import Mapping
 from collections import deque
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -185,6 +186,11 @@ ENV_VARS = [
     ("MATRIX_HOMESERVER",        "Homeserver URL",           "matrix",    False),
     ("MATRIX_ACCESS_TOKEN",      "Access Token",             "matrix",    True),
     ("MATRIX_USER_ID",           "User ID",                  "matrix",    False),
+    ("FEISHU_APP_ID",            "App ID",                   "lark",      False),
+    ("FEISHU_APP_SECRET",        "App Secret",               "lark",      True),
+    ("FEISHU_VERIFICATION_TOKEN","Verification Token",       "lark",      True),
+    ("FEISHU_ENCRYPT_KEY",       "Encrypt Key",              "lark",      True),
+    ("FEISHU_DOMAIN",            "Domain (feishu / lark)",   "lark",      False),
     ("GATEWAY_ALLOW_ALL_USERS",  "Allow all users",          "gateway",   False),
     ("ADMIN_USERNAME",           "Admin username",           "admin",     False),
     ("ADMIN_PASSWORD",           "Admin password",           "admin",     True),
@@ -273,6 +279,7 @@ CHANNEL_MAP  = {
     "Email":       "EMAIL_ADDRESS",
     "Mattermost":  "MATTERMOST_TOKEN",
     "Matrix":      "MATRIX_ACCESS_TOKEN",
+    "Lark":        "FEISHU_APP_ID",
 }
 
 
@@ -451,19 +458,215 @@ def build_hermes_env() -> dict[str, str]:
     return env
 
 
+def _env_flag_enabled(value: str | None) -> bool:
+    """Match the truthy spellings accepted by pinned Hermes v2026.7.1."""
+    return str(value or "").strip().lower() in {"1", "true", "yes"}
+
+
+def _coerce_port(value: str | None, default: int) -> int:
+    """Mirror Hermes' malformed-port fallback for the optional API adapter."""
+    try:
+        return int(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _config_flag_enabled(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return _env_flag_enabled(str(value))
+
+
+def _read_hermes_config() -> dict:
+    """Read config.yaml for listener settings that env overrides cannot disable."""
+    config_path = Path(HERMES_HOME) / "config.yaml"
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+    except ImportError:
+        return {}
+    try:
+        loaded = yaml.safe_load(config_path.read_text())
+        return loaded if isinstance(loaded, dict) else {}
+    except (OSError, UnicodeError, yaml.YAMLError):
+        # Gateway config loading is fail-open too; a malformed/unreadable YAML
+        # file is diagnosed by Hermes itself rather than breaking the Setup UI.
+        return {}
+
+
+def _yaml_api_server_settings(config: Mapping[str, object]) -> tuple[bool, int]:
+    """Mirror the pinned gateway's YAML merge order for the API listener."""
+    merged: dict = {}
+    merged_extra: dict = {}
+
+    gateway = config.get("gateway")
+    gateway_platforms = gateway.get("platforms") if isinstance(gateway, Mapping) else None
+    platforms = config.get("platforms")
+    for source in (gateway_platforms, platforms):
+        block = source.get("api_server") if isinstance(source, Mapping) else None
+        if not isinstance(block, Mapping):
+            continue
+        extra = block.get("extra")
+        if isinstance(extra, Mapping):
+            merged_extra.update(extra)
+        merged.update(block)
+
+    # A top-level api_server.enabled is bridged after the nested platform maps
+    # and therefore wins for enablement in Hermes v2026.7.1.
+    top_level = config.get("api_server")
+    if isinstance(top_level, Mapping) and "enabled" in top_level:
+        merged["enabled"] = top_level["enabled"]
+
+    return (
+        _config_flag_enabled(merged.get("enabled", False)),
+        _coerce_port(merged_extra.get("port"), 8642),
+    )
+
+
+def evaluate_port_preflight(
+    *,
+    process_env: Mapping[str, str] | None = None,
+    hermes_env: Mapping[str, str] | None = None,
+    hermes_config: Mapping[str, object] | None = None,
+) -> dict:
+    """Return a secret-free view of ports that must be unique in this container.
+
+    ``PORT`` belongs to the public Starlette server, while the dashboard and
+    optional Hermes API adapter are internal listeners. The API adapter's env
+    must come from ``build_hermes_env()`` because values saved in the Setup UI's
+    persistent .env intentionally override Railway service variables.
+    """
+    process_env = os.environ if process_env is None else process_env
+    hermes_env = build_hermes_env() if hermes_env is None else hermes_env
+    hermes_config = _read_hermes_config() if hermes_config is None else hermes_config
+
+    config_api_enabled, config_api_port = _yaml_api_server_settings(hermes_config)
+    api_server_env_enabled = (
+        _env_flag_enabled(hermes_env.get("API_SERVER_ENABLED"))
+        or bool(str(hermes_env.get("API_SERVER_KEY", "")).strip())
+    )
+    api_port = config_api_port
+    raw_env_api_port = hermes_env.get("API_SERVER_PORT")
+    if api_server_env_enabled and raw_env_api_port:
+        # A valid env port overrides YAML. A malformed value is ignored by the
+        # gateway loader, leaving the YAML/default port in effect. Hermes only
+        # enters this override branch when the env itself activates the API.
+        try:
+            api_port = int(raw_env_api_port)
+        except (TypeError, ValueError):
+            pass
+
+    ports = {
+        "web": int(process_env.get("PORT", "8080")),
+        "dashboard": int(process_env.get("HERMES_DASHBOARD_PORT", "9119")),
+        "api_server": api_port,
+    }
+    # Upstream enables this adapter when either the explicit flag OR an API key
+    # is present. Keep the preflight's activation rule identical so a keyed API
+    # server cannot bypass collision detection.
+    api_server_enabled = config_api_enabled or api_server_env_enabled
+    conflicts: list[dict] = []
+
+    if ports["web"] == ports["dashboard"]:
+        conflicts.append({
+            "services": ["web", "dashboard"],
+            "port": ports["web"],
+            "message": (
+                f"The public web server and Hermes dashboard both use port {ports['web']}."
+            ),
+            "remediation": (
+                "Set Railway PORT=8080 and HERMES_DASHBOARD_PORT=9119, then redeploy."
+            ),
+        })
+
+    if api_server_enabled:
+        if ports["web"] == ports["api_server"]:
+            conflicts.append({
+                "services": ["web", "api_server"],
+                "port": ports["web"],
+                "message": (
+                    f"The public web server and Hermes API Server both use port {ports['web']}."
+                ),
+                "remediation": (
+                    "Set Railway PORT=8080 (recommended), or set API_SERVER_PORT to an "
+                    "unused internal port, then redeploy."
+                ),
+            })
+        if ports["dashboard"] == ports["api_server"]:
+            conflicts.append({
+                "services": ["dashboard", "api_server"],
+                "port": ports["dashboard"],
+                "message": (
+                    f"The Hermes dashboard and Hermes API Server both use port "
+                    f"{ports['dashboard']}."
+                ),
+                "remediation": (
+                    "Set HERMES_DASHBOARD_PORT=9119 and API_SERVER_PORT=8642, "
+                    "then redeploy."
+                ),
+            })
+
+    api_server_conflicts = any(
+        "api_server" in conflict["services"] for conflict in conflicts
+    )
+    api_server_action = None
+    if api_server_conflicts:
+        api_server_action = (
+            "block_gateway_start"
+            if config_api_enabled
+            else "disable_for_gateway_start"
+        )
+    return {
+        "ok": not conflicts,
+        "ports": ports,
+        "api_server_enabled": api_server_enabled,
+        "api_server_config_enabled": config_api_enabled,
+        "api_server_action": api_server_action,
+        "conflicts": conflicts,
+    }
+
+
+def prepare_gateway_env(
+    *,
+    process_env: Mapping[str, str] | None = None,
+    hermes_env: Mapping[str, str] | None = None,
+    hermes_config: Mapping[str, object] | None = None,
+) -> tuple[dict[str, str], dict]:
+    """Prepare a gateway env without persisting an automatic port remap.
+
+    For env-enabled API conflicts, disable only that adapter for this subprocess
+    run so messaging can still start. A config.yaml-enabled conflict is marked
+    as non-suppressible for Gateway.start() to block without mutating persisted
+    configuration. Setup keeps showing the actionable conflict either way.
+    """
+    gateway_env = dict(build_hermes_env() if hermes_env is None else hermes_env)
+    status = evaluate_port_preflight(
+        process_env=process_env,
+        hermes_env=gateway_env,
+        hermes_config=hermes_config,
+    )
+    if status["api_server_action"] == "disable_for_gateway_start":
+        gateway_env["API_SERVER_ENABLED"] = "false"
+        # Hermes also treats a non-empty key as implicit enablement, so the
+        # transient subprocess env must hide both activation paths.
+        gateway_env["API_SERVER_KEY"] = ""
+    return gateway_env, status
+
+
 def write_env(path: Path, data: dict[str, str]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     cat_order = ["model", "provider", "bedrock", "azure", "custom", "tool",
                  "telegram", "discord", "slack", "whatsapp",
-                 "email", "mattermost", "matrix", "gateway", "admin"]
+                 "email", "mattermost", "matrix", "lark", "gateway", "admin"]
     cat_labels = {
         "model": "Model", "provider": "Providers",
         "bedrock": "AWS Bedrock", "azure": "Azure Foundry",
         "custom": "Custom Endpoint", "tool": "Tools",
         "telegram": "Telegram", "discord": "Discord", "slack": "Slack",
         "whatsapp": "WhatsApp", "email": "Email",
-        "mattermost": "Mattermost", "matrix": "Matrix", "gateway": "Gateway",
-        "admin": "Admin",
+        "mattermost": "Mattermost", "matrix": "Matrix", "lark": "Lark",
+        "gateway": "Gateway", "admin": "Admin",
     }
     key_cat = {k: c for k, _, c, _ in ENV_VARS}
     grouped: dict[str, list[str]] = {c: [] for c in cat_order}
@@ -975,7 +1178,35 @@ class Gateway:
         self.state = "starting"
         self._stopping = False
         try:
-            env = build_hermes_env()
+            env, port_preflight = prepare_gateway_env()
+            if port_preflight["api_server_action"] == "block_gateway_start":
+                self.state = "error"
+                warning = (
+                    "[port preflight] Gateway start blocked: config.yaml explicitly "
+                    "enables the Hermes API Server on a conflicting port. Fix Railway "
+                    "PORT or platforms.api_server.extra.port in the persisted Hermes "
+                    "config, then restart."
+                )
+                self.logs.append(warning)
+                print(f"[gateway] {warning}", flush=True)
+                return
+            if port_preflight["api_server_action"] == "disable_for_gateway_start":
+                conflict_ports = ", ".join(
+                    str(port)
+                    for port in sorted({
+                        conflict["port"]
+                        for conflict in port_preflight["conflicts"]
+                        if "api_server" in conflict["services"]
+                    })
+                )
+                warning = (
+                    "[port preflight] Hermes API Server disabled for this gateway run "
+                    f"because its port conflicts on {conflict_ports}. Messaging adapters "
+                    "will continue. Fix Railway PORT or the persisted Hermes "
+                    "API_SERVER_PORT, then restart."
+                )
+                self.logs.append(warning)
+                print(f"[gateway] {warning}", flush=True)
             model = env.get("LLM_MODEL", "")
             provider_key = next((env.get(k, "") for k in PROVIDER_KEYS if env.get(k)), "")
             print(f"[gateway] model={model or '⚠ NOT SET'} | provider_key={'set' if provider_key else '⚠ NOT SET'}", flush=True)
@@ -1115,7 +1346,7 @@ class Dashboard:
     """Manages the `hermes dashboard` subprocess (native Hermes web UI).
 
     Bound to loopback only — we expose it to the public internet through our
-    reverse proxy on $PORT, where edge basic auth guards every request.
+    reverse proxy on $PORT, where the template's cookie auth guards every request.
     The dashboard is independent of the gateway: it reads config files
     directly and tolerates a stopped gateway.
 
@@ -1141,6 +1372,21 @@ class Dashboard:
 
     async def start(self):
         if self.proc and self.proc.returncode is None:
+            return
+        port_preflight = evaluate_port_preflight()
+        dashboard_conflict = next((
+            conflict
+            for conflict in port_preflight["conflicts"]
+            if set(conflict["services"]) == {"web", "dashboard"}
+        ), None)
+        if dashboard_conflict:
+            warning = (
+                "Port preflight skipped the Hermes dashboard because it conflicts "
+                f"with the public web server on port {dashboard_conflict['port']}. "
+                "Setup remains available; fix the Railway variables and redeploy."
+            )
+            self.logs.append(warning)
+            print(f"[dashboard] {warning}", flush=True)
             return
         try:
             self.proc = await asyncio.create_subprocess_exec(
@@ -1418,7 +1664,12 @@ async def api_status(request: Request):
         name: {"configured": bool(v := data.get(key,"")) and v.lower() not in ("false","0","no")}
         for name, key in CHANNEL_MAP.items()
     }
-    return JSONResponse({"gateway": gw.status(), "providers": providers, "channels": channels})
+    return JSONResponse({
+        "gateway": gw.status(),
+        "providers": providers,
+        "channels": channels,
+        "port_preflight": evaluate_port_preflight(),
+    })
 
 
 async def api_logs(request: Request):
@@ -1558,6 +1809,23 @@ async def api_pairing_revoke(request: Request):
         del approved[uid]
         _wjson(p, approved)
     return JSONResponse({"ok": True})
+
+
+async def api_pairing_reset_lockout(request: Request):
+    if err := guard(request): return err
+    try: body = await request.json()
+    except Exception: return JSONResponse({"error": "Invalid JSON"}, status_code=400)
+    platform = body.get("platform", "")
+    if not platform:
+        return JSONResponse({"error": "platform required"}, status_code=400)
+    rate_limit_path = PAIRING_DIR / "_rate_limits.json"
+    limits = _pjson(rate_limit_path)
+    keys_removed = [k for k in list(limits) if k.endswith(f":{platform}")]
+    for k in keys_removed:
+        del limits[k]
+    if keys_removed:
+        _wjson(rate_limit_path, limits)
+    return JSONResponse({"ok": True, "keys_removed": keys_removed})
 
 
 # ── Reverse proxy → Hermes dashboard ──────────────────────────────────────────
@@ -1704,6 +1972,13 @@ async def auto_start():
 
 @asynccontextmanager
 async def lifespan(app):
+    port_preflight = evaluate_port_preflight()
+    for conflict in port_preflight["conflicts"]:
+        print(
+            f"[server] Port preflight: {conflict['message']} "
+            f"{conflict['remediation']}",
+            flush=True,
+        )
     # Dashboard runs always — it's the user-facing UI after setup is done,
     # and it's independent of gateway state.
     asyncio.create_task(dash.start())
@@ -1896,7 +2171,8 @@ routes = [
     Route("/setup/api/pairing/approve",         api_pairing_approve, methods=["POST"]),
     Route("/setup/api/pairing/deny",            api_pairing_deny,    methods=["POST"]),
     Route("/setup/api/pairing/approved",        api_pairing_approved),
-    Route("/setup/api/pairing/revoke",          api_pairing_revoke,  methods=["POST"]),
+    Route("/setup/api/pairing/revoke",          api_pairing_revoke,          methods=["POST"]),
+    Route("/setup/api/pairing/reset-lockout",   api_pairing_reset_lockout,   methods=["POST"]),
     Route("/setup/api/oauth/xai/start",         api_oauth_xai_start,  methods=["POST"]),
     Route("/setup/api/oauth/xai/status",        api_oauth_xai_status),
     Route("/setup/api/oauth/xai",               api_oauth_xai_delete, methods=["DELETE"]),

--- a/templates/index.html
+++ b/templates/index.html
@@ -417,6 +417,31 @@
   .stat-value.red    { color: var(--red); }
   .stat-value.yellow { color: var(--yellow); }
 
+  /* ── Runtime preflight warning ───────────────────── */
+  .port-alert {
+    background: rgba(248,81,73,0.08);
+    border: 1px solid rgba(248,81,73,0.45);
+    border-radius: 8px;
+    padding: 14px 16px;
+    margin-bottom: 16px;
+    color: var(--text);
+    font-size: 13px;
+    line-height: 1.55;
+  }
+  .port-alert-title {
+    color: var(--red);
+    font-family: var(--font-mono);
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+  .port-alert-item + .port-alert-item { margin-top: 8px; }
+  .port-alert code {
+    color: var(--yellow);
+    font-family: var(--font-mono);
+    font-size: 12px;
+  }
+  .port-alert-note { color: var(--text-dim); margin-top: 8px; }
+
   /* ── Action row ───────────────────────────────────── */
   .action-row { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 20px; }
 
@@ -780,6 +805,30 @@
       </div>
       <div class="panel-body">
 
+        <template x-if="status.port_preflight && !status.port_preflight.ok">
+          <div class="port-alert" role="alert">
+            <div class="port-alert-title">⚠ Port configuration conflict</div>
+            <template x-for="(conflict, index) in status.port_preflight.conflicts" :key="index">
+              <div class="port-alert-item">
+                <div x-text="conflict.message"></div>
+                <code x-text="conflict.remediation"></code>
+              </div>
+            </template>
+            <div class="port-alert-note">
+              Current ports:
+              <code x-text="'PORT=' + status.port_preflight.ports.web"></code>,
+              <code x-text="'HERMES_DASHBOARD_PORT=' + status.port_preflight.ports.dashboard"></code>,
+              <code x-text="'API_SERVER_PORT=' + status.port_preflight.ports.api_server"></code>.
+              <span x-show="status.port_preflight.api_server_action === 'disable_for_gateway_start'">
+                The conflicting API adapter will be disabled on the next gateway start; messaging channels remain active.
+              </span>
+              <span x-show="status.port_preflight.api_server_action === 'block_gateway_start'">
+                The API server is explicitly enabled in persisted config.yaml, so gateway start is blocked until you fix that configuration.
+              </span>
+            </div>
+          </div>
+        </template>
+
         <div style="background:rgba(98,114,255,0.06);border:1px solid rgba(98,114,255,0.2);border-radius:8px;padding:10px 14px;margin-bottom:16px;font-size:13px;color:var(--text-dim);">
           New to Hermes? Head over to the <a href="#" @click.prevent="page='guide'" style="color:var(--accent2);text-decoration:none;font-weight:500;">How to Setup</a> section for a step-by-step guide on getting started.
         </div>
@@ -1062,6 +1111,22 @@
             </div>
           </div>
 
+          <!-- Lark -->
+          <div class="toggle-row" @click="channelsEnabled.lark=!channelsEnabled.lark; if(!channelsEnabled.lark) clearChannel('lark')">
+            <input type="checkbox" :checked="channelsEnabled.lark" @click.stop @change="channelsEnabled.lark=$event.target.checked; if(!channelsEnabled.lark) clearChannel('lark')">
+            <span class="toggle-icon">🪶</span>
+            <span class="toggle-label">Lark</span>
+          </div>
+          <div class="toggle-body" x-show="channelsEnabled.lark">
+            <div class="toggle-fields">
+              <div><label class="field-label">App ID</label><input type="text" :value="vars.FEISHU_APP_ID||''" @input="vars.FEISHU_APP_ID=$event.target.value" placeholder="cli_..."></div>
+              <div><label class="field-label">App Secret</label><input type="password" :value="vars.FEISHU_APP_SECRET||''" @input="vars.FEISHU_APP_SECRET=$event.target.value"></div>
+              <div><label class="field-label">Verification Token</label><input type="password" :value="vars.FEISHU_VERIFICATION_TOKEN||''" @input="vars.FEISHU_VERIFICATION_TOKEN=$event.target.value" placeholder="optional, webhook mode"></div>
+              <div><label class="field-label">Encrypt Key</label><input type="password" :value="vars.FEISHU_ENCRYPT_KEY||''" @input="vars.FEISHU_ENCRYPT_KEY=$event.target.value" placeholder="optional, webhook mode"></div>
+              <div><label class="field-label">Domain</label><input type="text" :value="vars.FEISHU_DOMAIN||''" @input="vars.FEISHU_DOMAIN=$event.target.value" placeholder="feishu (CN) or lark (intl)"></div>
+            </div>
+          </div>
+
           <!-- WhatsApp -->
           <div class="toggle-row" style="border-bottom:none;" @click="channelsEnabled.whatsapp=!channelsEnabled.whatsapp; vars.WHATSAPP_ENABLED=channelsEnabled.whatsapp?'true':'false'">
             <input type="checkbox" :checked="channelsEnabled.whatsapp" @click.stop @change="channelsEnabled.whatsapp=$event.target.checked; vars.WHATSAPP_ENABLED=$event.target.checked?'true':'false'">
@@ -1229,6 +1294,7 @@
             <div style="display:flex;gap:8px;">
               <button class="btn sm success" @click="approve(r.platform,r.code)">Approve</button>
               <button class="btn sm danger"  @click="deny(r.platform,r.code)">Deny</button>
+              <button class="btn sm" style="opacity:.6;font-size:11px;" @click="resetLockout(r.platform)" title="Clear rate-limit lockout for this platform">Reset lockout</button>
             </div>
           </div>
         </template>
@@ -1452,7 +1518,7 @@ function app() {
 
     channelsEnabled: {
       telegram: false, discord: false, slack: false,
-      email: false, mattermost: false, matrix: false, whatsapp: false,
+      email: false, mattermost: false, matrix: false, lark: false, whatsapp: false,
     },
 
     toolsEnabled: Object.fromEntries(tools.map(t => [t.key, false])),
@@ -1538,6 +1604,7 @@ function app() {
         email:      ['EMAIL_ADDRESS','EMAIL_PASSWORD','EMAIL_IMAP_HOST','EMAIL_SMTP_HOST'],
         mattermost: ['MATTERMOST_URL','MATTERMOST_TOKEN'],
         matrix:     ['MATRIX_HOMESERVER','MATRIX_ACCESS_TOKEN','MATRIX_USER_ID'],
+        lark:       ['FEISHU_APP_ID','FEISHU_APP_SECRET','FEISHU_VERIFICATION_TOKEN','FEISHU_ENCRYPT_KEY','FEISHU_DOMAIN'],
         whatsapp:   ['WHATSAPP_ENABLED'],
       };
       for (const k of keysMap[ch] || []) this.vars[k] = '';
@@ -1602,6 +1669,7 @@ function app() {
             email:      !!(this.vars.EMAIL_ADDRESS),
             mattermost: !!(this.vars.MATTERMOST_URL),
             matrix:     !!(this.vars.MATRIX_HOMESERVER),
+            lark:       !!(this.vars.FEISHU_APP_ID),
             whatsapp:   this.vars.WHATSAPP_ENABLED === 'true',
           };
           // Detect active tools
@@ -1705,6 +1773,11 @@ function app() {
       if (!confirm('Revoke access for this user?')) return;
       await fetch('/setup/api/pairing/revoke', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({platform,user_id}) });
       this.notify('Revoked', true); await this.loadPairing();
+    },
+    async resetLockout(platform) {
+      const r = await fetch('/setup/api/pairing/reset-lockout', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({platform}) });
+      if (r.ok) { this.notify(`Lockout cleared for ${platform}`, true); }
+      else { this.notify('Reset failed', false); }
     },
 
     fmtDate(ts) {

--- a/tests/test_port_preflight.py
+++ b/tests/test_port_preflight.py
@@ -1,0 +1,223 @@
+import asyncio
+import os
+import unittest
+from os import environ
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault("ADMIN_PASSWORD", "test-password")
+import server
+
+
+class PortPreflightTests(unittest.TestCase):
+    def setUp(self):
+        config_patch = patch.object(server, "_read_hermes_config", return_value={})
+        config_patch.start()
+        self.addCleanup(config_patch.stop)
+
+    def test_detects_enabled_api_server_collision_with_railway_port(self):
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "true"},
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertEqual(status["ports"]["web"], 8642)
+        self.assertEqual(status["ports"]["api_server"], 8642)
+        self.assertEqual(
+            status["conflicts"][0]["services"],
+            ["web", "api_server"],
+        )
+        self.assertIn("PORT=8080", status["conflicts"][0]["remediation"])
+
+    def test_ignores_api_server_port_when_adapter_is_disabled(self):
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "false"},
+        )
+
+        self.assertTrue(status["ok"])
+        self.assertEqual(status["conflicts"], [])
+
+    def test_reports_dashboard_collision(self):
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "9119", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "false"},
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertEqual(
+            status["conflicts"][0]["services"],
+            ["web", "dashboard"],
+        )
+
+    def test_gateway_env_disables_only_conflicting_api_adapter_for_this_run(self):
+        original = {
+            "LLM_MODEL": "example/model",
+            "API_SERVER_ENABLED": "true",
+            "API_SERVER_PORT": "8642",
+        }
+
+        gateway_env, status = server.prepare_gateway_env(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env=original,
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertEqual(status["api_server_action"], "disable_for_gateway_start")
+        self.assertEqual(gateway_env["API_SERVER_ENABLED"], "false")
+        self.assertEqual(gateway_env["LLM_MODEL"], "example/model")
+        self.assertEqual(original["API_SERVER_ENABLED"], "true")
+
+    def test_api_key_also_enables_and_is_suppressed_for_conflicting_run(self):
+        gateway_env, status = server.prepare_gateway_env(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "false", "API_SERVER_KEY": "secret"},
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertTrue(status["api_server_enabled"])
+        self.assertNotIn("secret", repr(status))
+        self.assertEqual(status["api_server_action"], "disable_for_gateway_start")
+        self.assertEqual(gateway_env["API_SERVER_ENABLED"], "false")
+        self.assertEqual(gateway_env["API_SERVER_KEY"], "")
+
+    def test_gateway_env_keeps_api_server_enabled_when_ports_are_unique(self):
+        gateway_env, status = server.prepare_gateway_env(
+            process_env={"PORT": "8080", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "true", "API_SERVER_PORT": "8642"},
+        )
+
+        self.assertTrue(status["ok"])
+        self.assertIsNone(status["api_server_action"])
+        self.assertEqual(gateway_env["API_SERVER_ENABLED"], "true")
+
+    def test_yaml_enabled_api_collision_requires_blocking_gateway_start(self):
+        gateway_env, status = server.prepare_gateway_env(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "false"},
+            hermes_config={
+                "platforms": {
+                    "api_server": {"enabled": True, "extra": {"port": 8642}},
+                },
+            },
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertTrue(status["api_server_config_enabled"])
+        self.assertEqual(status["api_server_action"], "block_gateway_start")
+        self.assertEqual(gateway_env["API_SERVER_ENABLED"], "false")
+        self.assertNotIn("API_SERVER_KEY", gateway_env)
+
+    def test_env_api_port_overrides_yaml_api_port(self):
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "9999", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "true", "API_SERVER_PORT": "9999"},
+            hermes_config={
+                "platforms": {
+                    "api_server": {"enabled": True, "extra": {"port": 8642}},
+                },
+            },
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertEqual(status["ports"]["api_server"], 9999)
+
+    def test_inactive_env_port_does_not_override_yaml_enabled_api_port(self):
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "false", "API_SERVER_PORT": "9999"},
+            hermes_config={
+                "platforms": {
+                    "api_server": {"enabled": True, "extra": {"port": 8642}},
+                },
+            },
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertEqual(status["ports"]["api_server"], 8642)
+        self.assertEqual(status["api_server_action"], "block_gateway_start")
+
+    def test_malformed_api_port_falls_back_to_upstream_default(self):
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "true", "API_SERVER_PORT": "bad"},
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertEqual(status["ports"]["api_server"], 8642)
+
+    def test_persisted_dotenv_overrides_railway_api_port(self):
+        with TemporaryDirectory() as tmpdir:
+            env_file = Path(tmpdir) / ".env"
+            env_file.write_text("API_SERVER_ENABLED=true\nAPI_SERVER_PORT=8642\n")
+            with (
+                patch.object(server, "ENV_FILE", env_file),
+                patch.dict(
+                    environ,
+                    {"API_SERVER_ENABLED": "true", "API_SERVER_PORT": "9999"},
+                    clear=False,
+                ),
+            ):
+                merged = server.build_hermes_env()
+
+        self.assertEqual(merged["API_SERVER_PORT"], "8642")
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env=merged,
+        )
+        self.assertFalse(status["ok"])
+
+
+class RuntimePreflightTests(unittest.IsolatedAsyncioTestCase):
+    async def test_gateway_does_not_start_when_yaml_api_collision_cannot_be_suppressed(self):
+        gateway = server.Gateway()
+        status = {
+            "ok": False,
+            "api_server_action": "block_gateway_start",
+            "conflicts": [{
+                "services": ["web", "api_server"],
+                "port": 8642,
+            }],
+        }
+
+        with (
+            patch.object(server, "prepare_gateway_env", return_value=({}, status)),
+            patch.object(asyncio, "create_subprocess_exec", new=AsyncMock()) as spawn,
+        ):
+            await gateway.start()
+
+        spawn.assert_not_awaited()
+        self.assertEqual(gateway.state, "error")
+        self.assertIn("config.yaml", gateway.logs[-1])
+
+    async def test_dashboard_does_not_compete_for_public_web_port(self):
+        dashboard = server.Dashboard()
+        conflict = server.evaluate_port_preflight(
+            process_env={"PORT": "9119", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "false"},
+        )
+
+        with (
+            patch.object(server, "evaluate_port_preflight", return_value=conflict),
+            patch.object(asyncio, "create_subprocess_exec", new=AsyncMock()) as spawn,
+        ):
+            await dashboard.start()
+
+        spawn.assert_not_awaited()
+        self.assertIn("Setup remains available", dashboard.logs[-1])
+
+
+class SetupWarningTests(unittest.TestCase):
+    def test_setup_page_renders_port_preflight_warning(self):
+        template = (Path(server.__file__).parent / "templates" / "index.html").read_text()
+
+        self.assertIn("status.port_preflight", template)
+        self.assertIn("Port configuration conflict", template)
+        self.assertIn("conflict.remediation", template)
+        self.assertIn("block_gateway_start", template)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR brings three operator-facing improvements from the Railway template fork:

### Lark / Feishu setup support

- registers `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_VERIFICATION_TOKEN`, `FEISHU_ENCRYPT_KEY`, and `FEISHU_DOMAIN` in the template's environment-variable registry
- adds a Lark toggle and matching credential fields to the Setup UI
- includes Lark in saved `.env` grouping, configured-channel detection, and channel-clear behavior
- passes these settings through to Hermes' existing Lark adapter; this template does not introduce a separate messaging implementation

### Pairing lockout recovery

- adds `POST /setup/api/pairing/reset-lockout`
- clears `_rate_limits.json` entries for the selected platform and returns the keys removed
- adds a **Reset lockout** action beside pending pairing requests, so an operator can recover after repeated failed approval attempts without editing persistent files manually

### Railway listener port safety

- preflights the effective public web, native dashboard, and optional API server ports before starting child processes
- reads API enablement and port precedence from Railway/process variables, persisted `.env`, and `~/.hermes/config.yaml`
- exposes actionable collision diagnostics through the setup status API and a warning at the top of Setup
- prevents API-server reconnect loops without silently remapping ports or mutating persisted user configuration
- documents port ownership, precedence, and recovery steps

## Why

The Setup UI previously had no way to configure the Lark/Feishu variables already consumed by Hermes, and pairing lockouts required manual state-file intervention.

Separately, Railway injects `PORT` for the public listener. If it is configured as `8642`, it collides with Hermes' optional API server default and can cause repeated `Reconnect api_server failed` / `address already in use` errors. Checking only Railway variables is insufficient because the effective Hermes configuration may also come from persisted `.env` or `config.yaml`.

## Port-conflict behavior

| Collision | Safe response |
| --- | --- |
| Web port vs. native dashboard | Keep the public Setup app running and skip the internal dashboard listener |
| Web/dashboard vs. env-enabled API server | Suppress the API listener for that gateway run so messaging channels can continue; leave persisted settings unchanged |
| Web/dashboard vs. `config.yaml`-enabled API server | Block gateway startup and show explicit remediation because silently overriding YAML would violate the user's effective configuration |

The warning identifies the conflicting listeners, reports their effective ports and configuration source, and tells the operator which Railway variable or Hermes setting to change.

## Validation

- `python -m unittest discover -s tests -v` — 14 port-preflight tests passed
- Python bytecode compilation passed
- Jinja template compilation passed, including the combined Setup UI changes
- critical Ruff checks passed
- the remote PR compare contains one commit and matches the five-file net diff from the fork's `main`
- the combined tree was deployed on Railway: deployment reached `SUCCESS`, Uvicorn bound to `0.0.0.0:8080`, the dashboard bound to `127.0.0.1:9119`, `/health` returned 200, and startup logs contained no reconnect loop, bind error, traceback, or preflight warning

## Known gaps

- automated tests currently cover the port-preflight behavior; the Lark/Feishu form plumbing and pairing reset endpoint do not yet have dedicated regression tests
- live Lark/Feishu message delivery, webhook verification/encryption, and international Lark domain behavior were not exercised
- the reset action was not exercised against a real lockout produced by five failed pairing approvals
- a full Docker image build and an API client connected to a non-conflicting `8642` listener were not tested

## Notes

- no new dependencies
- no automatic port remapping
- no writes to persisted `.env` or `config.yaml` during port-conflict handling
- listener precedence and Lark/Feishu variable names remain aligned with the Hermes version pinned by this template
