### PR TITLE
Prevent agent-triggered exits from leaving Railway deployments offline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,13 @@ RUN apt-get update && \
 # oversized image (>5 MB / >8000px), which then bakes into immutable history
 # and bricks the session on Anthropic's non-retryable 400. We bake it in.
 # When bumping HERMES_REF, re-check hermes-agent's pyproject.toml [all] and
-# the extras below against the new release's pyproject.toml.
+# the extras below against the new release's pyproject.toml.  The build-time
+# hardener also deliberately fails closed when its reviewed upstream anchor
+# changes, forcing the PID-1 safety guard to be re-validated on every bump.
+COPY build_tools/harden_hermes.py /app/build_tools/harden_hermes.py
 RUN git clone --depth 1 --branch ${HERMES_REF} https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent && \
     cd /opt/hermes-agent && \
+    python /app/build_tools/harden_hermes.py /opt/hermes-agent/tools/approval.py && \
     uv pip install --system --no-cache -e ".[all,messaging,tts-premium,honcho,bedrock,anthropic,edge-tts,hindsight,vision]" && \
     cd /opt/hermes-agent/web && \
     npm install --silent && \

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Deploy [Hermes Agent](https://github.com/NousResearch/hermes-agent) on [Railway]
 - **Basic Auth** — password-protected admin panel
 - **Reset Config** — one-click reset to start fresh
 - **Backup & Restore** — download a full snapshot (config, credentials, chat history, memories, skills) as a zip, and restore it — including into a fresh project — to clone a deployment. Not encrypted; a safety snapshot is taken automatically before every restore.
+- **Runtime Recovery** — critical dashboard supervision, readiness-aware health checks, and restart-on-clean-exit deployment policy
 
 ## Getting Started
 
@@ -96,6 +97,22 @@ Railway Container
 
 The admin server runs on `$PORT` and manages the Hermes gateway as a child process. Config is stored in `/data/.hermes/.env` and `/data/.hermes/config.yaml`. Gateway stdout/stderr is captured into a ring buffer and streamed to the Logs panel.
 
+## Runtime Hardening and Recovery
+
+This template applies three complementary safeguards around Hermes' local terminal runtime:
+
+1. **PID 1 command guard at image build time.** `build_tools/harden_hermes.py` adds an unconditional Hermes approval rule for real `kill ... 1` command forms, including signal flags, absolute `/bin/kill` paths, wrappers, and multi-PID target lists. The image build fails if the reviewed upstream anchor changes, so a Hermes version bump cannot silently drop the guard.
+2. **Critical-process supervision.** If the native Hermes dashboard exits unexpectedly, the admin server restarts it with capped exponential backoff. `/health` returns `503 degraded` while the dashboard is unavailable and includes both dashboard and gateway state for diagnosis.
+3. **Platform-level recovery.** `railway.toml` uses Railway's `ALWAYS` restart policy, so the deployment is recreated even when the top-level process exits cleanly with code 0. The Dockerfile alone owns the `tini` entrypoint; the Railway config does not override or duplicate it.
+
+Railway currently makes the `ALWAYS` policy available only on paid plans. Free/trial deployments cannot provide the same clean-exit recovery guarantee; changing the template back to `ON_FAILURE` accepts the original failure mode where an intentional `SIGTERM` can leave the deployment stopped. See Railway's [restart policy documentation](https://docs.railway.com/deployments/restart-policy).
+
+### Safe restart procedure
+
+Restart or redeploy this service from Railway's deployment controls. Do not ask Hermes to restart its own container, and do not approve shell commands that signal PID 1 (`kill 1`, `kill -TERM 1`, and variants). The in-image command guard is defense in depth for the known command path, not a general-purpose sandbox for arbitrary code execution.
+
+Hermes' dashboard, gateway, and terminal tools still share one container and PID namespace in this single-service template. Strong containment requires moving agent execution into a separate Railway service/container with a private API boundary; that is a larger architecture change than this recovery hardening.
+
 ## Running Locally
 
 ```bash
@@ -112,7 +129,7 @@ This template pins a specific Hermes Agent release in the `Dockerfile` (`ARG HER
 - **Recommended:** set a `HERMES_REF` service variable in Railway to any upstream [release tag](https://github.com/NousResearch/hermes-agent/releases) (e.g. `v2026.7.1`), then redeploy. It's passed in as a Docker build arg and overrides the Dockerfile default — no code change needed.
 - **Or** bump `ARG HERMES_REF` in the `Dockerfile` and redeploy.
 
-The "Update" button inside the Hermes dashboard is a **no-op on Railway** (it detects a container install and refuses) — the image is immutable, so a runtime self-update wouldn't survive a redeploy. Bump `HERMES_REF` and redeploy instead. When jumping releases, re-check that the Dockerfile's install extras still match upstream's `pyproject.toml`.
+The "Update" button inside the Hermes dashboard is a **no-op on Railway** (it detects a container install and refuses) — the image is immutable, so a runtime self-update wouldn't survive a redeploy. Bump `HERMES_REF` and redeploy instead. When jumping releases, re-check that the Dockerfile's install extras still match upstream's `pyproject.toml` **and** re-validate the PID 1 approval guard against the new `tools/approval.py`. The build intentionally fails when that reviewed source anchor changes.
 
 ## Credits
 

--- a/build_tools/harden_hermes.py
+++ b/build_tools/harden_hermes.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Apply template-owned safety guards to the pinned Hermes source tree.
+
+The Railway template currently runs Hermes' local terminal backend in the same
+PID namespace as the public controller.  Until those workloads are separated,
+signalling PID 1 from an agent terminal would terminate the whole deployment.
+Patch Hermes' unconditional command floor during the image build and fail the
+build if the pinned upstream source has drifted away from the reviewed anchor.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+# Mirrors Hermes v2026.7.1's command-position anchor.  Keeping the complete
+# expression here makes the exact injected regex directly unit-testable without
+# importing Hermes and all of its runtime dependencies into this template.
+COMMAND_POSITION_PATTERN = (
+    r"(?:^|[;&|\n`]|\$\()"
+    r"\s*"
+    r"(?:sudo\s+(?:-[^\s]+\s+)*)?"
+    r"(?:env\s+(?:\w+=\S*\s+)*)?"
+    r"(?:(?:exec|nohup|setsid|time)\s+)*"
+    r"\s*"
+)
+
+# Match a real kill command at a shell command position, including the common
+# absolute binary paths and signal syntaxes.  PID 1 may appear anywhere in the
+# target list, but PID prefixes such as 10/11 and command text passed as data do
+# not match.
+PID1_PATTERN = (
+    COMMAND_POSITION_PATTERN
+    + r"(?:command\s+|builtin\s+)*"
+    + r"(?:/(?:usr/)?bin/)?kill\s+"
+    + r"(?:(?:-(?:s|signal)|--signal)\s+\S+\s+|(?:-[^\s]+\s+|--\s+))*"
+    + r"(?:[^\s;&|`]+\s+)*"
+    + r"[\"']?1[\"']?(?=\s|$|[;&|)`])"
+)
+PID1_DESCRIPTION = "signal container init process (PID 1)"
+
+# This exact line is present in the pinned v2026.7.1 approval floor.  An exact
+# anchor is intentional: a Hermes version bump must re-review the safety layer
+# instead of silently producing an image without the local hardening.
+UPSTREAM_ANCHOR = (
+    "    (r'\\bkill\\s+(-[^\\s]+\\s+)*-1\\b', \"kill all processes\"),\n"
+)
+PID1_ENTRY = f"    ({PID1_PATTERN!r}, {PID1_DESCRIPTION!r}),\n"
+
+
+def patch_source(source: str) -> str:
+    """Return approval.py with the PID 1 guard inserted exactly once."""
+    if PID1_DESCRIPTION in source:
+        return source
+
+    anchor_count = source.count(UPSTREAM_ANCHOR)
+    if anchor_count != 1:
+        raise RuntimeError(
+            "Hermes approval.py hardline anchor changed "
+            f"(expected once, found {anchor_count}); review the new upstream "
+            "guard implementation before rebuilding"
+        )
+    return source.replace(UPSTREAM_ANCHOR, UPSTREAM_ANCHOR + PID1_ENTRY, 1)
+
+
+def patch_file(path: Path) -> bool:
+    """Patch ``path`` atomically enough for an image-build layer.
+
+    Returns True when the file changed and False when it was already hardened.
+    """
+    original = path.read_text(encoding="utf-8")
+    patched = patch_source(original)
+    if patched == original:
+        return False
+    path.write_text(patched, encoding="utf-8")
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("approval_file", type=Path)
+    args = parser.parse_args()
+    changed = patch_file(args.approval_file)
+    action = "patched" if changed else "already hardened"
+    print(f"[build-hardening] {action}: {args.approval_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/railway.toml
+++ b/railway.toml
@@ -3,8 +3,7 @@ builder = "dockerfile"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "/usr/bin/tini -g -- /app/start.sh"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
-restartPolicyType = "on_failure"
+restartPolicyType = "ALWAYS"
 restartPolicyMaxRetries = 10

--- a/server.py
+++ b/server.py
@@ -39,7 +39,7 @@ import tempfile
 import time
 import zipfile
 from collections import deque
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 
 import httpx
@@ -1137,17 +1137,29 @@ class Dashboard:
 
     All subprocess output is streamed to our stdout (→ Railway logs) with a
     `[dashboard]` prefix AND retained in a ring buffer for diagnostics.
-    Unexpected exits are explicitly logged with their return code.
+    Unexpected exits are explicitly logged with their return code and
+    supervised with bounded exponential backoff.  The dashboard is the
+    user-facing critical process, so its state also drives /health readiness.
     """
 
     def __init__(self):
         self.proc: asyncio.subprocess.Process | None = None
+        self.state = "stopped"
         self.logs: deque[str] = deque(maxlen=300)
+        self.started_at: float | None = None
+        self.restarts = 0
         self._drain_task: asyncio.Task | None = None
+        self._respawn_task: asyncio.Task | None = None
+        self._stopping = False
+        self._recent_exits: list[float] = []
 
-    async def start(self):
+    async def start(self, *, reset_budget: bool = True):
         if self.proc and self.proc.returncode is None:
             return
+        if reset_budget:
+            self._recent_exits.clear()
+        self.state = "starting"
+        self._stopping = False
         try:
             self.proc = await asyncio.create_subprocess_exec(
                 "hermes", "dashboard",
@@ -1170,37 +1182,106 @@ class Dashboard:
                 stderr=asyncio.subprocess.STDOUT,
                 env=build_hermes_env(),
             )
+            self.state = "running"
+            self.started_at = time.time()
             print(f"[dashboard] spawned pid={self.proc.pid} → {HERMES_DASHBOARD_URL}", flush=True)
-            self._drain_task = asyncio.create_task(self._drain())
+            self._drain_task = asyncio.create_task(self._drain(self.proc))
         except Exception as e:
-            print(f"[dashboard] FAILED to spawn: {e!r}", flush=True)
+            self.state = "error"
+            message = f"FAILED to spawn: {e!r}"
+            self.logs.append(message)
+            print(f"[dashboard] {message}", flush=True)
+            self._queue_respawn()
 
-    async def _drain(self):
+    async def _drain(self, proc: asyncio.subprocess.Process):
         """Stream subprocess output to Railway logs (prefixed) and a ring buffer."""
-        assert self.proc and self.proc.stdout
+        assert proc.stdout
         try:
-            async for raw in self.proc.stdout:
+            async for raw in proc.stdout:
                 line = ANSI_ESCAPE.sub("", raw.decode(errors="replace").rstrip())
                 self.logs.append(line)
                 print(f"[dashboard] {line}", flush=True)
         except Exception as e:
             print(f"[dashboard] drain error: {e!r}", flush=True)
         finally:
-            rc = self.proc.returncode if self.proc else None
-            if rc is not None and rc != 0:
-                print(f"[dashboard] EXITED with code {rc} — reverse proxy will return 503 until restart", flush=True)
-            elif rc == 0:
-                print(f"[dashboard] exited cleanly (code 0)", flush=True)
+            # stdout reaching EOF normally coincides with process exit, but
+            # wait() guarantees returncode is populated before classifying it.
+            rc = await proc.wait()
+            if proc is not self.proc:
+                return
+            if self._stopping:
+                return
+            self.state = "error"
+            self.started_at = None
+            message = f"EXITED with code {rc} — supervising restart"
+            self.logs.append(message)
+            print(f"[dashboard] {message}", flush=True)
+            self._queue_respawn()
+
+    def _queue_respawn(self) -> None:
+        """Schedule one dashboard recovery loop after an unexpected failure."""
+        if self._stopping:
+            return
+        if self._respawn_task and not self._respawn_task.done():
+            return
+        self._respawn_task = asyncio.create_task(self._supervise_respawn())
+
+    async def _supervise_respawn(self) -> None:
+        """Retry dashboard startup with capped backoff until it stays alive."""
+        try:
+            while not self._stopping:
+                now = time.monotonic()
+                self._recent_exits = [
+                    exited_at
+                    for exited_at in self._recent_exits
+                    if now - exited_at < RESPAWN_WINDOW_S
+                ]
+                self._recent_exits.append(now)
+                attempt = len(self._recent_exits)
+                delay = min(
+                    RESPAWN_BASE_DELAY * 2 ** (attempt - 1),
+                    RESPAWN_MAX_DELAY,
+                )
+                self.state = "restarting"
+                self.logs.append(
+                    f"[dashboard] restarting in {int(delay)}s (attempt {attempt})"
+                )
+                await asyncio.sleep(delay)
+                if self._stopping:
+                    return
+                if self.proc and self.proc.returncode is None:
+                    return
+                self.restarts += 1
+                await self.start(reset_budget=False)
+                if self.proc and self.proc.returncode is None:
+                    return
+        finally:
+            self._respawn_task = None
 
     async def stop(self):
+        self._stopping = True
+        current_task = asyncio.current_task()
+        if (
+            self._respawn_task
+            and self._respawn_task is not current_task
+            and not self._respawn_task.done()
+        ):
+            self._respawn_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._respawn_task
         if not self.proc or self.proc.returncode is not None:
+            self.state = "stopped"
+            self.started_at = None
             return
+        self.state = "stopping"
         self.proc.terminate()
         try:
             await asyncio.wait_for(self.proc.wait(), timeout=5)
         except asyncio.TimeoutError:
             self.proc.kill()
             await self.proc.wait()
+        self.state = "stopped"
+        self.started_at = None
 
     async def restart(self):
         """Respawn so a freshly-saved provider key reaches the embedded Chat tab.
@@ -1211,7 +1292,21 @@ class Dashboard:
         staying broken until a full redeploy.
         """
         await self.stop()
+        self.restarts += 1
         await self.start()
+
+    def status(self) -> dict:
+        uptime = (
+            int(time.time() - self.started_at)
+            if self.started_at and self.state == "running"
+            else None
+        )
+        return {
+            "state": self.state,
+            "pid": self.proc.pid if self.proc and self.proc.returncode is None else None,
+            "uptime": uptime,
+            "restarts": self.restarts,
+        }
 
 
 dash = Dashboard()
@@ -1348,7 +1443,16 @@ async def page_index(request: Request):
 
 
 async def route_health(request: Request):
-    return JSONResponse({"status": "ok", "gateway": gw.state})
+    dashboard_status = dash.status()
+    healthy = dashboard_status["state"] == "running"
+    return JSONResponse(
+        {
+            "status": "ok" if healthy else "degraded",
+            "gateway": gw.state,
+            "dashboard": dashboard_status,
+        },
+        status_code=200 if healthy else 503,
+    )
 
 
 async def api_config_get(request: Request):

--- a/tests/test_runtime_hardening.py
+++ b/tests/test_runtime_hardening.py
@@ -1,0 +1,204 @@
+import asyncio
+import importlib.util
+import json
+import os
+import re
+import tomllib
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+os.environ.setdefault("ADMIN_PASSWORD", "test-password")
+import server
+
+
+ROOT = Path(server.__file__).parent
+
+
+def load_build_hardener():
+    path = ROOT / "build_tools" / "harden_hermes.py"
+    if not path.exists():
+        raise AssertionError(f"missing build-time Hermes hardener: {path}")
+    spec = importlib.util.spec_from_file_location("harden_hermes", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"could not load build-time Hermes hardener: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class HermesPidOneGuardTests(unittest.TestCase):
+    def test_guard_matches_pid_one_signal_commands_at_command_positions(self):
+        hardener = load_build_hardener()
+        guard = re.compile(hardener.PID1_PATTERN, re.IGNORECASE | re.DOTALL)
+
+        blocked = (
+            "kill 1",
+            "kill -TERM 1",
+            "kill -15 1",
+            "kill -s TERM 1",
+            "kill --signal=KILL 1",
+            "/bin/kill -TERM 1",
+            "sudo /usr/bin/kill -TERM 1",
+            "echo ready && kill -TERM 2 1",
+            "$(kill -TERM '1')",
+        )
+        for command in blocked:
+            with self.subTest(command=command):
+                self.assertIsNotNone(guard.search(command))
+
+    def test_guard_does_not_block_pid_prefixes_or_command_text_used_as_data(self):
+        hardener = load_build_hardener()
+        guard = re.compile(hardener.PID1_PATTERN, re.IGNORECASE | re.DOTALL)
+
+        allowed = (
+            "kill -TERM 10",
+            "kill -TERM 11",
+            "echo 'kill -TERM 1'",
+            "printf '%s' 'kill 1'",
+            "gh issue create --body 'kill -TERM 1'",
+        )
+        for command in allowed:
+            with self.subTest(command=command):
+                self.assertIsNone(guard.search(command))
+
+    def test_build_patch_is_idempotent_and_fails_closed_on_upstream_drift(self):
+        hardener = load_build_hardener()
+        source = "HARDLINE_PATTERNS = [\n" + hardener.UPSTREAM_ANCHOR + "]\n"
+
+        once = hardener.patch_source(source)
+        twice = hardener.patch_source(once)
+
+        self.assertEqual(once, twice)
+        self.assertEqual(once.count(hardener.PID1_DESCRIPTION), 1)
+        with self.assertRaisesRegex(RuntimeError, "anchor"):
+            hardener.patch_source("HARDLINE_PATTERNS = []\n")
+
+
+class CriticalProcessHealthTests(unittest.IsolatedAsyncioTestCase):
+    async def test_health_is_unavailable_while_dashboard_is_down(self):
+        dashboard_status = {
+            "state": "restarting",
+            "pid": None,
+            "uptime": None,
+            "restarts": 2,
+        }
+        with patch.object(server.dash, "status", return_value=dashboard_status):
+            response = await server.route_health(None)
+
+        body = json.loads(response.body)
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(body["status"], "degraded")
+        self.assertEqual(body["dashboard"], dashboard_status)
+
+    async def test_health_is_available_when_dashboard_is_running(self):
+        dashboard_status = {
+            "state": "running",
+            "pid": 123,
+            "uptime": 5,
+            "restarts": 0,
+        }
+        with patch.object(server.dash, "status", return_value=dashboard_status):
+            response = await server.route_health(None)
+
+        body = json.loads(response.body)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["gateway"], server.gw.state)
+
+    async def test_unexpected_dashboard_exit_queues_a_respawn(self):
+        class EmptyOutput:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+        class ExitedProcess:
+            pid = 456
+            returncode = -15
+            stdout = EmptyOutput()
+
+            async def wait(self):
+                return self.returncode
+
+        dashboard = server.Dashboard()
+        process = ExitedProcess()
+        dashboard.proc = process
+        dashboard.state = "running"
+
+        with patch.object(dashboard, "_queue_respawn", new=Mock()) as queue:
+            await dashboard._drain(process)
+
+        self.assertEqual(dashboard.state, "error")
+        queue.assert_called_once_with()
+
+    async def test_deliberate_dashboard_stop_does_not_queue_a_respawn(self):
+        class EmptyOutput:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+        class ExitedProcess:
+            pid = 789
+            returncode = 0
+            stdout = EmptyOutput()
+
+            async def wait(self):
+                return self.returncode
+
+        dashboard = server.Dashboard()
+        process = ExitedProcess()
+        dashboard.proc = process
+        dashboard.state = "stopping"
+        dashboard._stopping = True
+
+        with patch.object(dashboard, "_queue_respawn", new=Mock()) as queue:
+            await dashboard._drain(process)
+
+        queue.assert_not_called()
+
+    async def test_dashboard_supervisor_restarts_after_backoff(self):
+        class DeadProcess:
+            pid = 111
+            returncode = 1
+
+        class LiveProcess:
+            pid = 222
+            returncode = None
+
+        dashboard = server.Dashboard()
+        dashboard.proc = DeadProcess()
+        dashboard.state = "error"
+
+        async def make_live(*, reset_budget):
+            self.assertFalse(reset_budget)
+            dashboard.proc = LiveProcess()
+            dashboard.state = "running"
+
+        with (
+            patch.object(asyncio, "sleep", return_value=None) as sleep,
+            patch.object(dashboard, "start", side_effect=make_live) as start,
+        ):
+            await dashboard._supervise_respawn()
+
+        sleep.assert_awaited_once_with(server.RESPAWN_BASE_DELAY)
+        start.assert_awaited_once_with(reset_budget=False)
+        self.assertEqual(dashboard.restarts, 1)
+        self.assertEqual(dashboard.state, "running")
+
+
+class RailwayLifecyclePolicyTests(unittest.TestCase):
+    def test_clean_exit_is_restarted_and_dockerfile_owns_the_entrypoint(self):
+        config = tomllib.loads((ROOT / "railway.toml").read_text())
+        deploy = config["deploy"]
+
+        self.assertEqual(deploy["restartPolicyType"].lower(), "always")
+        self.assertNotIn("startCommand", deploy)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- patch the pinned Hermes approval floor during image build to hard-block real `kill ... 1` command forms
- fail the image build when the reviewed upstream `approval.py` anchor changes
- supervise unexpected native Dashboard exits with capped exponential backoff
- make `/health` readiness-aware and return `503 degraded` while the Dashboard is unavailable
- use Railway's `ALWAYS` restart policy and let the Dockerfile remain the single owner of the `tini` entrypoint

## Root cause

Hermes' local terminal runs in the same Railway container and PID namespace as the template controller. The pinned Hermes guard blocks `kill -1` (all processes), but it does not block signalling literal PID 1. A `SIGTERM` delivered to PID 1 shuts the service down cleanly, and Railway's previous `ON_FAILURE` policy does not restart a zero-exit deployment. Separately, the template previously logged a native Dashboard exit without supervising it or reflecting it in `/health`.

This change adds recovery at three layers: command guard, child-process supervisor, and platform restart policy.

## User and operator impact

- common PID 1 signal commands are rejected before terminal execution
- an unexpected Dashboard exit recovers automatically instead of leaving the reverse proxy on permanent 503s
- health responses include Dashboard state, PID, uptime, and restart count
- a clean top-level exit is restarted on Railway paid plans
- Hermes version bumps fail closed until the build-time guard is re-reviewed against the new upstream source

Railway currently reserves the `ALWAYS` restart policy for paid plans; the README documents that limitation. The command guard is defense in depth, not a substitute for a separate execution container/PID namespace.

## Validation

- 9 upstream-branch hardening tests pass
- Ruff fatal/static checks pass
- Python `compileall`, `bash -n start.sh`, and `git diff --check` pass
- complete Docker image build succeeds
- in-image Hermes probe classifies `kill -TERM 1` as a hardline block
- live container test: after Dashboard PID 12 received `SIGKILL`, it recovered as PID 21 and `/health` reported `restarts: 1`

## Scope

No new runtime dependency is introduced. Strong execution isolation remains a follow-up architecture change.
