### PR TITLE
Expose Lark/Feishu settings in the setup UI

### DIFF
--- a/server.py
+++ b/server.py
@@ -191,6 +191,11 @@ ENV_VARS = [
     ("MATRIX_HOMESERVER",        "Homeserver URL",           "matrix",    False),
     ("MATRIX_ACCESS_TOKEN",      "Access Token",             "matrix",    True),
     ("MATRIX_USER_ID",           "User ID",                  "matrix",    False),
+    ("FEISHU_APP_ID",             "App ID",                   "lark",      False),
+    ("FEISHU_APP_SECRET",         "App Secret",               "lark",      True),
+    ("FEISHU_VERIFICATION_TOKEN", "Verification Token",       "lark",      True),
+    ("FEISHU_ENCRYPT_KEY",        "Encrypt Key",              "lark",      True),
+    ("FEISHU_DOMAIN",             "Domain (feishu / lark)",   "lark",      False),
     ("GATEWAY_ALLOW_ALL_USERS",  "Allow all users",          "gateway",   False),
     ("ADMIN_USERNAME",           "Admin username",           "admin",     False),
     ("ADMIN_PASSWORD",           "Admin password",           "admin",     True),
@@ -279,6 +284,7 @@ CHANNEL_MAP  = {
     "Email":       "EMAIL_ADDRESS",
     "Mattermost":  "MATTERMOST_TOKEN",
     "Matrix":      "MATRIX_ACCESS_TOKEN",
+    "Lark":        "FEISHU_APP_ID",
 }
 
 
@@ -461,15 +467,15 @@ def write_env(path: Path, data: dict[str, str]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     cat_order = ["model", "provider", "bedrock", "azure", "custom", "tool",
                  "telegram", "discord", "slack", "whatsapp",
-                 "email", "mattermost", "matrix", "gateway", "admin"]
+                 "email", "mattermost", "matrix", "lark", "gateway", "admin"]
     cat_labels = {
         "model": "Model", "provider": "Providers",
         "bedrock": "AWS Bedrock", "azure": "Azure Foundry",
         "custom": "Custom Endpoint", "tool": "Tools",
         "telegram": "Telegram", "discord": "Discord", "slack": "Slack",
         "whatsapp": "WhatsApp", "email": "Email",
-        "mattermost": "Mattermost", "matrix": "Matrix", "gateway": "Gateway",
-        "admin": "Admin",
+        "mattermost": "Mattermost", "matrix": "Matrix", "lark": "Lark",
+        "gateway": "Gateway", "admin": "Admin",
     }
     key_cat = {k: c for k, _, c, _ in ENV_VARS}
     grouped: dict[str, list[str]] = {c: [] for c in cat_order}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1108,6 +1108,22 @@
             </div>
           </div>
 
+          <!-- Lark -->
+          <div class="toggle-row" @click="channelsEnabled.lark=!channelsEnabled.lark; if(!channelsEnabled.lark) clearChannel('lark')">
+            <input type="checkbox" :checked="channelsEnabled.lark" @click.stop @change="channelsEnabled.lark=$event.target.checked; if(!channelsEnabled.lark) clearChannel('lark')">
+            <span class="toggle-icon">🪶</span>
+            <span class="toggle-label">Lark</span>
+          </div>
+          <div class="toggle-body" x-show="channelsEnabled.lark">
+            <div class="toggle-fields">
+              <div><label class="field-label">App ID</label><input type="text" :value="vars.FEISHU_APP_ID||''" @input="vars.FEISHU_APP_ID=$event.target.value" placeholder="cli_..."></div>
+              <div><label class="field-label">App Secret</label><input type="password" :value="vars.FEISHU_APP_SECRET||''" @input="vars.FEISHU_APP_SECRET=$event.target.value"></div>
+              <div><label class="field-label">Verification Token</label><input type="password" :value="vars.FEISHU_VERIFICATION_TOKEN||''" @input="vars.FEISHU_VERIFICATION_TOKEN=$event.target.value" placeholder="optional, webhook mode"></div>
+              <div><label class="field-label">Encrypt Key</label><input type="password" :value="vars.FEISHU_ENCRYPT_KEY||''" @input="vars.FEISHU_ENCRYPT_KEY=$event.target.value" placeholder="optional, webhook mode"></div>
+              <div><label class="field-label">Domain</label><input type="text" :value="vars.FEISHU_DOMAIN||''" @input="vars.FEISHU_DOMAIN=$event.target.value" placeholder="feishu (CN) or lark (intl)"></div>
+            </div>
+          </div>
+
           <!-- WhatsApp -->
           <div class="toggle-row" style="border-bottom:none;" @click="channelsEnabled.whatsapp=!channelsEnabled.whatsapp; vars.WHATSAPP_ENABLED=channelsEnabled.whatsapp?'true':'false'">
             <input type="checkbox" :checked="channelsEnabled.whatsapp" @click.stop @change="channelsEnabled.whatsapp=$event.target.checked; vars.WHATSAPP_ENABLED=$event.target.checked?'true':'false'">
@@ -1591,7 +1607,7 @@ function app() {
 
     channelsEnabled: {
       telegram: false, discord: false, slack: false,
-      email: false, mattermost: false, matrix: false, whatsapp: false,
+      email: false, mattermost: false, matrix: false, lark: false, whatsapp: false,
     },
 
     toolsEnabled: Object.fromEntries(tools.map(t => [t.key, false])),
@@ -1677,6 +1693,7 @@ function app() {
         email:      ['EMAIL_ADDRESS','EMAIL_PASSWORD','EMAIL_IMAP_HOST','EMAIL_SMTP_HOST'],
         mattermost: ['MATTERMOST_URL','MATTERMOST_TOKEN'],
         matrix:     ['MATRIX_HOMESERVER','MATRIX_ACCESS_TOKEN','MATRIX_USER_ID'],
+        lark:       ['FEISHU_APP_ID','FEISHU_APP_SECRET','FEISHU_VERIFICATION_TOKEN','FEISHU_ENCRYPT_KEY','FEISHU_DOMAIN'],
         whatsapp:   ['WHATSAPP_ENABLED'],
       };
       for (const k of keysMap[ch] || []) this.vars[k] = '';
@@ -1741,6 +1758,7 @@ function app() {
             email:      !!(this.vars.EMAIL_ADDRESS),
             mattermost: !!(this.vars.MATTERMOST_URL),
             matrix:     !!(this.vars.MATRIX_HOMESERVER),
+            lark:       !!(this.vars.FEISHU_APP_ID),
             whatsapp:   this.vars.WHATSAPP_ENABLED === 'true',
           };
           // Detect active tools

--- a/tests/test_lark_setup.py
+++ b/tests/test_lark_setup.py
@@ -1,0 +1,60 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+os.environ.setdefault("ADMIN_PASSWORD", "test-password")
+import server
+
+
+ROOT = Path(server.__file__).parent
+LARK_KEYS = (
+    "FEISHU_APP_ID",
+    "FEISHU_APP_SECRET",
+    "FEISHU_VERIFICATION_TOKEN",
+    "FEISHU_ENCRYPT_KEY",
+    "FEISHU_DOMAIN",
+)
+
+
+class LarkSetupTests(unittest.TestCase):
+    def test_lark_variables_are_registered_with_secret_metadata(self):
+        definitions = {
+            key: (category, secret)
+            for key, _label, category, secret in server.ENV_VARS
+            if key in LARK_KEYS
+        }
+
+        self.assertEqual(set(definitions), set(LARK_KEYS))
+        self.assertEqual(definitions["FEISHU_APP_ID"], ("lark", False))
+        self.assertEqual(definitions["FEISHU_APP_SECRET"], ("lark", True))
+        self.assertEqual(definitions["FEISHU_VERIFICATION_TOKEN"], ("lark", True))
+        self.assertEqual(definitions["FEISHU_ENCRYPT_KEY"], ("lark", True))
+        self.assertEqual(definitions["FEISHU_DOMAIN"], ("lark", False))
+        self.assertEqual(server.CHANNEL_MAP["Lark"], "FEISHU_APP_ID")
+
+    def test_lark_variables_are_written_as_a_group(self):
+        values = {key: f"value-for-{key.lower()}" for key in LARK_KEYS}
+
+        with tempfile.TemporaryDirectory() as directory:
+            env_file = Path(directory) / ".env"
+            server.write_env(env_file, values)
+            contents = env_file.read_text()
+
+        self.assertIn("# Lark", contents)
+        for key, value in values.items():
+            self.assertIn(f"{key}={value}", contents)
+
+    def test_setup_ui_can_detect_and_clear_every_lark_variable(self):
+        template = (ROOT / "templates" / "index.html").read_text()
+
+        self.assertIn("channelsEnabled.lark", template)
+        self.assertIn("lark:       !!(this.vars.FEISHU_APP_ID)", template)
+        for key in LARK_KEYS:
+            self.assertIn(f"vars.{key}", template)
+            self.assertIn(f"'{key}'", template)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- register Hermes' existing `FEISHU_*` credentials in the Railway setup API
- add Lark/Feishu fields, saved-state detection, and clear behavior to the setup UI
- keep the change on the existing Hermes messaging adapter instead of introducing a new integration path

This is the Lark/Feishu portion of #63, split out so it can be reviewed and merged independently.

## Verification

- 3 focused `unittest` cases in the built Hermes image
- `ruff check --select E9,F63,F7,F82 server.py tests/test_lark_setup.py`
- `python3 -m compileall -q server.py tests/test_lark_setup.py`
- `git diff --check`

## Known gap

- A live Lark tenant handshake was not exercised in this branch.
