### PR TITLE
Add operator recovery for pairing lockouts

### DIFF
--- a/server.py
+++ b/server.py
@@ -1566,6 +1566,27 @@ async def api_pairing_revoke(request: Request):
     return JSONResponse({"ok": True})
 
 
+async def api_pairing_reset_lockout(request: Request):
+    if err := guard(request): return err
+    try: body = await request.json()
+    except Exception: return JSONResponse({"error": "Invalid JSON"}, status_code=400)
+    platform = str(body.get("platform", "")).strip().lower()
+    if not re.fullmatch(r"[a-z0-9_-]+", platform):
+        return JSONResponse({"error": "valid platform required"}, status_code=400)
+    rate_limit_path = PAIRING_DIR / "_rate_limits.json"
+    limits = _pjson(rate_limit_path)
+    keys_removed = [
+        key
+        for key in (f"_failures:{platform}", f"_lockout:{platform}")
+        if key in limits
+    ]
+    for key in keys_removed:
+        del limits[key]
+    if keys_removed:
+        _wjson(rate_limit_path, limits)
+    return JSONResponse({"ok": True, "keys_removed": keys_removed})
+
+
 # ── Backup & Restore ─────────────────────────────────────────────────────────
 # Thin wrapper around hermes' OWN `hermes backup` / `hermes import` CLI
 # (hermes_cli/backup.py, verified against v2026.7.1) rather than reimplementing
@@ -2122,7 +2143,8 @@ routes = [
     Route("/setup/api/pairing/approve",         api_pairing_approve, methods=["POST"]),
     Route("/setup/api/pairing/deny",            api_pairing_deny,    methods=["POST"]),
     Route("/setup/api/pairing/approved",        api_pairing_approved),
-    Route("/setup/api/pairing/revoke",          api_pairing_revoke,  methods=["POST"]),
+    Route("/setup/api/pairing/revoke",          api_pairing_revoke, methods=["POST"]),
+    Route("/setup/api/pairing/reset-lockout",   api_pairing_reset_lockout, methods=["POST"]),
     Route("/setup/api/oauth/xai/start",         api_oauth_xai_start,  methods=["POST"]),
     Route("/setup/api/oauth/xai/status",        api_oauth_xai_status),
     Route("/setup/api/oauth/xai",               api_oauth_xai_delete, methods=["DELETE"]),

--- a/templates/index.html
+++ b/templates/index.html
@@ -1275,6 +1275,7 @@
             <div style="display:flex;gap:8px;">
               <button class="btn sm success" @click="approve(r.platform,r.code)">Approve</button>
               <button class="btn sm danger"  @click="deny(r.platform,r.code)">Deny</button>
+              <button class="btn sm" style="opacity:.6;font-size:11px;" @click="resetLockout(r.platform)" title="Clear rate-limit lockout for this platform">Reset lockout</button>
             </div>
           </div>
         </template>
@@ -1844,6 +1845,11 @@ function app() {
       if (!confirm('Revoke access for this user?')) return;
       await fetch('/setup/api/pairing/revoke', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({platform,user_id}) });
       this.notify('Revoked', true); await this.loadPairing();
+    },
+    async resetLockout(platform) {
+      const r = await fetch('/setup/api/pairing/reset-lockout', { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({platform}) });
+      if (r.ok) { this.notify(`Lockout cleared for ${platform}`, true); }
+      else { this.notify('Reset failed', false); }
     },
 
     async downloadBackup() {

--- a/tests/test_pairing_lockout.py
+++ b/tests/test_pairing_lockout.py
@@ -1,0 +1,76 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+os.environ.setdefault("ADMIN_PASSWORD", "test-password")
+import server
+
+
+ROOT = Path(server.__file__).parent
+
+
+class JsonRequest:
+    def __init__(self, body):
+        self.body = body
+
+    async def json(self):
+        return self.body
+
+
+class PairingLockoutTests(unittest.IsolatedAsyncioTestCase):
+    async def test_reset_removes_only_lockout_metadata_for_selected_platform(self):
+        limits = {
+            "_failures:telegram": 4,
+            "_lockout:telegram": 9999999999,
+            "telegram:user-1": 1234,
+            "discord:telegram": 5678,
+            "_failures:discord": 2,
+            "_lockout:discord": 9999999999,
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            pairing_dir = Path(directory)
+            rate_limits = pairing_dir / "_rate_limits.json"
+            rate_limits.write_text(json.dumps(limits))
+            with (
+                patch.object(server, "PAIRING_DIR", pairing_dir),
+                patch.object(server, "guard", return_value=None),
+            ):
+                response = await server.api_pairing_reset_lockout(JsonRequest({"platform": " Telegram "}))
+            saved = json.loads(rate_limits.read_text())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            json.loads(response.body)["keys_removed"],
+            ["_failures:telegram", "_lockout:telegram"],
+        )
+        self.assertEqual(
+            saved,
+            {
+                "telegram:user-1": 1234,
+                "discord:telegram": 5678,
+                "_failures:discord": 2,
+                "_lockout:discord": 9999999999,
+            },
+        )
+
+    async def test_reset_rejects_invalid_platform_identifiers(self):
+        with patch.object(server, "guard", return_value=None):
+            response = await server.api_pairing_reset_lockout(JsonRequest({"platform": "../telegram"}))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.body), {"error": "valid platform required"})
+
+    def test_setup_ui_exposes_the_reset_action(self):
+        template = (ROOT / "templates" / "index.html").read_text()
+
+        self.assertIn("@click=\"resetLockout(r.platform)\"", template)
+        self.assertIn("fetch('/setup/api/pairing/reset-lockout'", template)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an authenticated setup endpoint to clear a platform's Hermes pairing lockout
- expose the recovery action next to pending pairing requests
- remove only `_failures:<platform>` and `_lockout:<platform>` metadata, preserving user request throttles and other platforms

This is the pairing-recovery portion of #63, split out so it can be reviewed and merged independently. While splitting it, the reset logic was narrowed to Hermes v2026.7.1's exact lockout keys; the old combined PR used a suffix match that could remove an unrelated rate-limit entry.

## Verification

- 3 focused `unittest` cases in the built Hermes image
- verified key names against the pinned Hermes v2026.7.1 `gateway/pairing.py`
- `ruff check --select E9,F63,F7,F82 server.py tests/test_pairing_lockout.py`
- `python3 -m compileall -q server.py tests/test_pairing_lockout.py`
- `git diff --check`

## Known gap

- A concurrent gateway write to `_rate_limits.json` during the reset was not stress-tested.
