### PR TITLE
Prevent Railway listener port collisions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,12 @@ GATEWAY_ALLOW_ALL_USERS=true
 # Options: local, docker, modal, ssh
 TERMINAL_ENV=local
 TERMINAL_TIMEOUT=60
+
+# ── Optional: Hermes API server ───────────────────────────────────────────────
+# Railway's public PORT belongs to the template web server (recommended: 8080).
+# Keep this optional internal API port distinct from PORT and from the native
+# dashboard port HERMES_DASHBOARD_PORT (default: 9119). Uncomment these only
+# when enabling the API in this persisted file; .env overrides Railway values.
+# API_SERVER_ENABLED=false
+# API_SERVER_PORT=8642
+# API_SERVER_KEY=

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Hermes Agent interacts entirely through messaging channels — there is no chat 
 1. Click the **Deploy on Railway** button above
 2. Set the `ADMIN_PASSWORD` environment variable (or a random one will be generated and printed to deploy logs)
 3. Attach a **volume** mounted at `/data` (persists config across redeploys)
-4. Open your app URL — log in with username `admin` and your password
+4. Keep the Railway public `PORT` on `8080`; do not reuse the internal dashboard/API ports
+5. Open your app URL — log in with username `admin` and your password
 
 ### 4. Configure in the Admin Dashboard
 
@@ -64,12 +65,39 @@ Message your Telegram bot. If you're a new user, a pairing request will appear i
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PORT` | `8080` | Web server port (set automatically by Railway) |
+| `PORT` | `8080` | Public Starlette web server port. Railway routes traffic here. Do not set it to `9119` or `8642`. |
+| `HERMES_DASHBOARD_PORT` | `9119` | Internal Hermes dashboard port, proxied through the public web server. |
+| `API_SERVER_ENABLED` | `false` | Enables Hermes' optional OpenAI-compatible API server. |
+| `API_SERVER_PORT` | `8642` | Internal Hermes API server port when enabled. Must differ from `PORT` and `HERMES_DASHBOARD_PORT`. |
+| `API_SERVER_KEY` | *(unset)* | Optional bearer key for the API server. A non-empty value also enables the API server. |
 | `ADMIN_USERNAME` | `admin` | Basic auth username |
 | `ADMIN_PASSWORD` | *(auto-generated)* | Basic auth password — if unset, a random password is printed to logs |
 | `HERMES_REF` | *(pinned in Dockerfile)* | Hermes Agent version to install (any upstream git tag/branch). Set this to override the Dockerfile default without editing code — see [Updating Hermes](#updating-hermes). |
 
 All other configuration (LLM provider, model, channels, tools) is managed through the admin dashboard.
+
+### Port ownership and preflight
+
+All active listeners share one Railway container and must use distinct ports. The API port is reserved only when the optional API server is enabled (explicitly or by setting `API_SERVER_KEY`):
+
+| Listener | Recommended port | Exposure |
+|----------|------------------|----------|
+| Template web server (`PORT`) | `8080` | Public, through Railway |
+| Native Hermes dashboard (`HERMES_DASHBOARD_PORT`) | `9119` | Loopback only, reverse-proxied by the template |
+| Optional Hermes API server (`API_SERVER_PORT`) | `8642` | Internal unless you deliberately expose it |
+
+The template checks both the effective environment and persisted `config.yaml` before starting the gateway. It does **not** silently choose a new port. For an environment-enabled API server, it disables only the API adapter for that gateway start, keeps messaging channels running, and shows an actionable warning at the top of **Setup**. If `config.yaml` explicitly enables the conflicting API listener, the template blocks gateway start rather than mutating persistent configuration or entering a reconnect loop. Fix the conflicting port, then restart or redeploy.
+
+#### Troubleshooting: repeated `Reconnect api_server failed`
+
+If Railway logs repeatedly report `Reconnect api_server failed` or `address already in use`:
+
+1. Open **Railway → Service → Variables**.
+2. Set `PORT=8080`.
+3. Keep `HERMES_DASHBOARD_PORT=9119` and `API_SERVER_PORT=8642`, or choose other unused, distinct internal ports.
+4. Redeploy the service, then confirm the warning has disappeared from **Setup**.
+
+If API settings were previously saved into `/data/.hermes/.env`, update that persisted Hermes configuration as well: it takes precedence over Railway variables for child processes, so a stored `API_SERVER_PORT` can still create a collision.
 
 ## Supported Providers
 
@@ -87,11 +115,14 @@ Parallel (search), Firecrawl (scraping), Tavily (search), FAL (image gen), Brows
 
 ```
 Railway Container
-├── Python Admin Server (Starlette + Uvicorn)
-│   ├── /            — Admin dashboard (Basic Auth)
-│   ├── /health      — Health check (no auth)
-│   └── /api/*       — Config, status, logs, gateway, pairing
-└── hermes gateway   — Managed as async subprocess
+├── Python Admin Server (Starlette + Uvicorn) — 0.0.0.0:$PORT (public)
+│   ├── /setup       — Template setup/admin UI (cookie auth)
+│   ├── /setup/api/* — Config, status, logs, gateway, pairing
+│   ├── /health      — Railway health check (no auth)
+│   └── /*           — Reverse proxy to the native dashboard
+├── Native Hermes Dashboard — 127.0.0.1:9119 (internal)
+└── hermes gateway — managed as async subprocess
+    └── Optional API Server — 127.0.0.1:8642 (internal by default)
 ```
 
 The admin server runs on `$PORT` and manages the Hermes gateway as a child process. Config is stored in `/data/.hermes/.env` and `/data/.hermes/config.yaml`. Gateway stdout/stderr is captured into a ring buffer and streamed to the Logs panel.

--- a/server.py
+++ b/server.py
@@ -38,6 +38,7 @@ import signal
 import tempfile
 import time
 import zipfile
+from collections.abc import Mapping
 from collections import deque
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -455,6 +456,202 @@ def build_hermes_env() -> dict[str, str]:
     env = {**os.environ, "HERMES_HOME": HERMES_HOME}
     env.update(read_env(ENV_FILE))
     return env
+
+
+def _env_flag_enabled(value: str | None) -> bool:
+    """Match the truthy spellings accepted by pinned Hermes v2026.7.1."""
+    return str(value or "").strip().lower() in {"1", "true", "yes"}
+
+
+def _coerce_port(value: str | None, default: int) -> int:
+    """Mirror Hermes' malformed-port fallback for the optional API adapter."""
+    try:
+        return int(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _config_flag_enabled(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return _env_flag_enabled(str(value))
+
+
+def _read_hermes_config() -> dict:
+    """Read config.yaml for listener settings that env overrides cannot disable."""
+    config_path = Path(HERMES_HOME) / "config.yaml"
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+    except ImportError:
+        return {}
+    try:
+        loaded = yaml.safe_load(config_path.read_text())
+        return loaded if isinstance(loaded, dict) else {}
+    except (OSError, UnicodeError, yaml.YAMLError):
+        # Gateway config loading is fail-open too; a malformed/unreadable YAML
+        # file is diagnosed by Hermes itself rather than breaking the Setup UI.
+        return {}
+
+
+def _yaml_api_server_settings(config: Mapping[str, object]) -> tuple[bool, int]:
+    """Mirror the pinned gateway's YAML merge order for the API listener."""
+    merged: dict = {}
+    merged_extra: dict = {}
+
+    gateway = config.get("gateway")
+    gateway_platforms = gateway.get("platforms") if isinstance(gateway, Mapping) else None
+    platforms = config.get("platforms")
+    for source in (gateway_platforms, platforms):
+        block = source.get("api_server") if isinstance(source, Mapping) else None
+        if not isinstance(block, Mapping):
+            continue
+        extra = block.get("extra")
+        if isinstance(extra, Mapping):
+            merged_extra.update(extra)
+        merged.update(block)
+
+    # A top-level api_server.enabled is bridged after the nested platform maps
+    # and therefore wins for enablement in Hermes v2026.7.1.
+    top_level = config.get("api_server")
+    if isinstance(top_level, Mapping) and "enabled" in top_level:
+        merged["enabled"] = top_level["enabled"]
+
+    return (
+        _config_flag_enabled(merged.get("enabled", False)),
+        _coerce_port(merged_extra.get("port"), 8642),
+    )
+
+
+def evaluate_port_preflight(
+    *,
+    process_env: Mapping[str, str] | None = None,
+    hermes_env: Mapping[str, str] | None = None,
+    hermes_config: Mapping[str, object] | None = None,
+) -> dict:
+    """Return a secret-free view of ports that must be unique in this container.
+
+    ``PORT`` belongs to the public Starlette server, while the dashboard and
+    optional Hermes API adapter are internal listeners. The API adapter's env
+    must come from ``build_hermes_env()`` because values saved in the Setup UI's
+    persistent .env intentionally override Railway service variables.
+    """
+    process_env = os.environ if process_env is None else process_env
+    hermes_env = build_hermes_env() if hermes_env is None else hermes_env
+    hermes_config = _read_hermes_config() if hermes_config is None else hermes_config
+
+    config_api_enabled, config_api_port = _yaml_api_server_settings(hermes_config)
+    api_server_env_enabled = (
+        _env_flag_enabled(hermes_env.get("API_SERVER_ENABLED"))
+        or bool(str(hermes_env.get("API_SERVER_KEY", "")).strip())
+    )
+    api_port = config_api_port
+    raw_env_api_port = hermes_env.get("API_SERVER_PORT")
+    if api_server_env_enabled and raw_env_api_port:
+        # A valid env port overrides YAML. A malformed value is ignored by the
+        # gateway loader, leaving the YAML/default port in effect. Hermes only
+        # enters this override branch when the env itself activates the API.
+        try:
+            api_port = int(raw_env_api_port)
+        except (TypeError, ValueError):
+            pass
+
+    ports = {
+        "web": int(process_env.get("PORT", "8080")),
+        "dashboard": int(process_env.get("HERMES_DASHBOARD_PORT", "9119")),
+        "api_server": api_port,
+    }
+    # Upstream enables this adapter when either the explicit flag OR an API key
+    # is present. Keep the preflight's activation rule identical so a keyed API
+    # server cannot bypass collision detection.
+    api_server_enabled = config_api_enabled or api_server_env_enabled
+    conflicts: list[dict] = []
+
+    if ports["web"] == ports["dashboard"]:
+        conflicts.append({
+            "services": ["web", "dashboard"],
+            "port": ports["web"],
+            "message": (
+                f"The public web server and Hermes dashboard both use port {ports['web']}."
+            ),
+            "remediation": (
+                "Set Railway PORT=8080 and HERMES_DASHBOARD_PORT=9119, then redeploy."
+            ),
+        })
+
+    if api_server_enabled:
+        if ports["web"] == ports["api_server"]:
+            conflicts.append({
+                "services": ["web", "api_server"],
+                "port": ports["web"],
+                "message": (
+                    f"The public web server and Hermes API Server both use port {ports['web']}."
+                ),
+                "remediation": (
+                    "Set Railway PORT=8080 (recommended), or set API_SERVER_PORT to an "
+                    "unused internal port, then redeploy."
+                ),
+            })
+        if ports["dashboard"] == ports["api_server"]:
+            conflicts.append({
+                "services": ["dashboard", "api_server"],
+                "port": ports["dashboard"],
+                "message": (
+                    f"The Hermes dashboard and Hermes API Server both use port "
+                    f"{ports['dashboard']}."
+                ),
+                "remediation": (
+                    "Set HERMES_DASHBOARD_PORT=9119 and API_SERVER_PORT=8642, "
+                    "then redeploy."
+                ),
+            })
+
+    api_server_conflicts = any(
+        "api_server" in conflict["services"] for conflict in conflicts
+    )
+    api_server_action = None
+    if api_server_conflicts:
+        api_server_action = (
+            "block_gateway_start"
+            if config_api_enabled
+            else "disable_for_gateway_start"
+        )
+    return {
+        "ok": not conflicts,
+        "ports": ports,
+        "api_server_enabled": api_server_enabled,
+        "api_server_config_enabled": config_api_enabled,
+        "api_server_action": api_server_action,
+        "conflicts": conflicts,
+    }
+
+
+def prepare_gateway_env(
+    *,
+    process_env: Mapping[str, str] | None = None,
+    hermes_env: Mapping[str, str] | None = None,
+    hermes_config: Mapping[str, object] | None = None,
+) -> tuple[dict[str, str], dict]:
+    """Prepare a gateway env without persisting an automatic port remap.
+
+    For env-enabled API conflicts, disable only that adapter for this subprocess
+    run so messaging can still start. A config.yaml-enabled conflict is marked
+    as non-suppressible for Gateway.start() to block without mutating persisted
+    configuration. Setup keeps showing the actionable conflict either way.
+    """
+    gateway_env = dict(build_hermes_env() if hermes_env is None else hermes_env)
+    status = evaluate_port_preflight(
+        process_env=process_env,
+        hermes_env=gateway_env,
+        hermes_config=hermes_config,
+    )
+    if status["api_server_action"] == "disable_for_gateway_start":
+        gateway_env["API_SERVER_ENABLED"] = "false"
+        # Hermes also treats a non-empty key as implicit enablement, so the
+        # transient subprocess env must hide both activation paths.
+        gateway_env["API_SERVER_KEY"] = ""
+    return gateway_env, status
 
 
 def write_env(path: Path, data: dict[str, str]) -> None:
@@ -981,7 +1178,35 @@ class Gateway:
         self.state = "starting"
         self._stopping = False
         try:
-            env = build_hermes_env()
+            env, port_preflight = prepare_gateway_env()
+            if port_preflight["api_server_action"] == "block_gateway_start":
+                self.state = "error"
+                warning = (
+                    "[port preflight] Gateway start blocked: config.yaml explicitly "
+                    "enables the Hermes API Server on a conflicting port. Fix Railway "
+                    "PORT or platforms.api_server.extra.port in the persisted Hermes "
+                    "config, then restart."
+                )
+                self.logs.append(warning)
+                print(f"[gateway] {warning}", flush=True)
+                return
+            if port_preflight["api_server_action"] == "disable_for_gateway_start":
+                conflict_ports = ", ".join(
+                    str(port)
+                    for port in sorted({
+                        conflict["port"]
+                        for conflict in port_preflight["conflicts"]
+                        if "api_server" in conflict["services"]
+                    })
+                )
+                warning = (
+                    "[port preflight] Hermes API Server disabled for this gateway run "
+                    f"because its port conflicts on {conflict_ports}. Messaging adapters "
+                    "will continue. Fix Railway PORT or the persisted Hermes "
+                    "API_SERVER_PORT, then restart."
+                )
+                self.logs.append(warning)
+                print(f"[gateway] {warning}", flush=True)
             model = env.get("LLM_MODEL", "")
             provider_key = next((env.get(k, "") for k in PROVIDER_KEYS if env.get(k)), "")
             print(f"[gateway] model={model or '⚠ NOT SET'} | provider_key={'set' if provider_key else '⚠ NOT SET'}", flush=True)
@@ -1121,7 +1346,7 @@ class Dashboard:
     """Manages the `hermes dashboard` subprocess (native Hermes web UI).
 
     Bound to loopback only — we expose it to the public internet through our
-    reverse proxy on $PORT, where edge basic auth guards every request.
+    reverse proxy on $PORT, where the template's cookie auth guards every request.
     The dashboard is independent of the gateway: it reads config files
     directly and tolerates a stopped gateway.
 
@@ -1147,6 +1372,21 @@ class Dashboard:
 
     async def start(self):
         if self.proc and self.proc.returncode is None:
+            return
+        port_preflight = evaluate_port_preflight()
+        dashboard_conflict = next((
+            conflict
+            for conflict in port_preflight["conflicts"]
+            if set(conflict["services"]) == {"web", "dashboard"}
+        ), None)
+        if dashboard_conflict:
+            warning = (
+                "Port preflight skipped the Hermes dashboard because it conflicts "
+                f"with the public web server on port {dashboard_conflict['port']}. "
+                "Setup remains available; fix the Railway variables and redeploy."
+            )
+            self.logs.append(warning)
+            print(f"[dashboard] {warning}", flush=True)
             return
         try:
             self.proc = await asyncio.create_subprocess_exec(
@@ -1424,7 +1664,12 @@ async def api_status(request: Request):
         name: {"configured": bool(v := data.get(key,"")) and v.lower() not in ("false","0","no")}
         for name, key in CHANNEL_MAP.items()
     }
-    return JSONResponse({"gateway": gw.status(), "providers": providers, "channels": channels})
+    return JSONResponse({
+        "gateway": gw.status(),
+        "providers": providers,
+        "channels": channels,
+        "port_preflight": evaluate_port_preflight(),
+    })
 
 
 async def api_logs(request: Request):
@@ -1930,6 +2175,13 @@ async def auto_start():
 @asynccontextmanager
 async def lifespan(app):
     _sweep_stale_backup_tmpdirs()
+    port_preflight = evaluate_port_preflight()
+    for conflict in port_preflight["conflicts"]:
+        print(
+            f"[server] Port preflight: {conflict['message']} "
+            f"{conflict['remediation']}",
+            flush=True,
+        )
     # Dashboard runs always — it's the user-facing UI after setup is done,
     # and it's independent of gateway state.
     asyncio.create_task(dash.start())

--- a/templates/index.html
+++ b/templates/index.html
@@ -417,6 +417,31 @@
   .stat-value.red    { color: var(--red); }
   .stat-value.yellow { color: var(--yellow); }
 
+  /* ── Runtime preflight warning ───────────────────── */
+  .port-alert {
+    background: rgba(248,81,73,0.08);
+    border: 1px solid rgba(248,81,73,0.45);
+    border-radius: 8px;
+    padding: 14px 16px;
+    margin-bottom: 16px;
+    color: var(--text);
+    font-size: 13px;
+    line-height: 1.55;
+  }
+  .port-alert-title {
+    color: var(--red);
+    font-family: var(--font-mono);
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+  .port-alert-item + .port-alert-item { margin-top: 8px; }
+  .port-alert code {
+    color: var(--yellow);
+    font-family: var(--font-mono);
+    font-size: 12px;
+  }
+  .port-alert-note { color: var(--text-dim); margin-top: 8px; }
+
   /* ── Action row ───────────────────────────────────── */
   .action-row { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 20px; }
 
@@ -825,6 +850,30 @@
         <div class="panel-subtitle">Configure your Hermes Agent</div>
       </div>
       <div class="panel-body">
+
+        <template x-if="status.port_preflight && !status.port_preflight.ok">
+          <div class="port-alert" role="alert">
+            <div class="port-alert-title">⚠ Port configuration conflict</div>
+            <template x-for="(conflict, index) in status.port_preflight.conflicts" :key="index">
+              <div class="port-alert-item">
+                <div x-text="conflict.message"></div>
+                <code x-text="conflict.remediation"></code>
+              </div>
+            </template>
+            <div class="port-alert-note">
+              Current ports:
+              <code x-text="'PORT=' + status.port_preflight.ports.web"></code>,
+              <code x-text="'HERMES_DASHBOARD_PORT=' + status.port_preflight.ports.dashboard"></code>,
+              <code x-text="'API_SERVER_PORT=' + status.port_preflight.ports.api_server"></code>.
+              <span x-show="status.port_preflight.api_server_action === 'disable_for_gateway_start'">
+                The conflicting API adapter will be disabled on the next gateway start; messaging channels remain active.
+              </span>
+              <span x-show="status.port_preflight.api_server_action === 'block_gateway_start'">
+                The API server is explicitly enabled in persisted config.yaml, so gateway start is blocked until you fix that configuration.
+              </span>
+            </div>
+          </div>
+        </template>
 
         <div style="background:rgba(98,114,255,0.06);border:1px solid rgba(98,114,255,0.2);border-radius:8px;padding:10px 14px;margin-bottom:16px;font-size:13px;color:var(--text-dim);">
           New to Hermes? Head over to the <a href="#" @click.prevent="page='guide'" style="color:var(--accent2);text-decoration:none;font-weight:500;">How to Setup</a> section for a step-by-step guide on getting started.

--- a/tests/test_port_preflight.py
+++ b/tests/test_port_preflight.py
@@ -1,0 +1,223 @@
+import asyncio
+import os
+import unittest
+from os import environ
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault("ADMIN_PASSWORD", "test-password")
+import server
+
+
+class PortPreflightTests(unittest.TestCase):
+    def setUp(self):
+        config_patch = patch.object(server, "_read_hermes_config", return_value={})
+        config_patch.start()
+        self.addCleanup(config_patch.stop)
+
+    def test_detects_enabled_api_server_collision_with_railway_port(self):
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "true"},
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertEqual(status["ports"]["web"], 8642)
+        self.assertEqual(status["ports"]["api_server"], 8642)
+        self.assertEqual(
+            status["conflicts"][0]["services"],
+            ["web", "api_server"],
+        )
+        self.assertIn("PORT=8080", status["conflicts"][0]["remediation"])
+
+    def test_ignores_api_server_port_when_adapter_is_disabled(self):
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "false"},
+        )
+
+        self.assertTrue(status["ok"])
+        self.assertEqual(status["conflicts"], [])
+
+    def test_reports_dashboard_collision(self):
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "9119", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "false"},
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertEqual(
+            status["conflicts"][0]["services"],
+            ["web", "dashboard"],
+        )
+
+    def test_gateway_env_disables_only_conflicting_api_adapter_for_this_run(self):
+        original = {
+            "LLM_MODEL": "example/model",
+            "API_SERVER_ENABLED": "true",
+            "API_SERVER_PORT": "8642",
+        }
+
+        gateway_env, status = server.prepare_gateway_env(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env=original,
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertEqual(status["api_server_action"], "disable_for_gateway_start")
+        self.assertEqual(gateway_env["API_SERVER_ENABLED"], "false")
+        self.assertEqual(gateway_env["LLM_MODEL"], "example/model")
+        self.assertEqual(original["API_SERVER_ENABLED"], "true")
+
+    def test_api_key_also_enables_and_is_suppressed_for_conflicting_run(self):
+        gateway_env, status = server.prepare_gateway_env(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "false", "API_SERVER_KEY": "secret"},
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertTrue(status["api_server_enabled"])
+        self.assertNotIn("secret", repr(status))
+        self.assertEqual(status["api_server_action"], "disable_for_gateway_start")
+        self.assertEqual(gateway_env["API_SERVER_ENABLED"], "false")
+        self.assertEqual(gateway_env["API_SERVER_KEY"], "")
+
+    def test_gateway_env_keeps_api_server_enabled_when_ports_are_unique(self):
+        gateway_env, status = server.prepare_gateway_env(
+            process_env={"PORT": "8080", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "true", "API_SERVER_PORT": "8642"},
+        )
+
+        self.assertTrue(status["ok"])
+        self.assertIsNone(status["api_server_action"])
+        self.assertEqual(gateway_env["API_SERVER_ENABLED"], "true")
+
+    def test_yaml_enabled_api_collision_requires_blocking_gateway_start(self):
+        gateway_env, status = server.prepare_gateway_env(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "false"},
+            hermes_config={
+                "platforms": {
+                    "api_server": {"enabled": True, "extra": {"port": 8642}},
+                },
+            },
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertTrue(status["api_server_config_enabled"])
+        self.assertEqual(status["api_server_action"], "block_gateway_start")
+        self.assertEqual(gateway_env["API_SERVER_ENABLED"], "false")
+        self.assertNotIn("API_SERVER_KEY", gateway_env)
+
+    def test_env_api_port_overrides_yaml_api_port(self):
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "9999", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "true", "API_SERVER_PORT": "9999"},
+            hermes_config={
+                "platforms": {
+                    "api_server": {"enabled": True, "extra": {"port": 8642}},
+                },
+            },
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertEqual(status["ports"]["api_server"], 9999)
+
+    def test_inactive_env_port_does_not_override_yaml_enabled_api_port(self):
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "false", "API_SERVER_PORT": "9999"},
+            hermes_config={
+                "platforms": {
+                    "api_server": {"enabled": True, "extra": {"port": 8642}},
+                },
+            },
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertEqual(status["ports"]["api_server"], 8642)
+        self.assertEqual(status["api_server_action"], "block_gateway_start")
+
+    def test_malformed_api_port_falls_back_to_upstream_default(self):
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "true", "API_SERVER_PORT": "bad"},
+        )
+
+        self.assertFalse(status["ok"])
+        self.assertEqual(status["ports"]["api_server"], 8642)
+
+    def test_persisted_dotenv_overrides_railway_api_port(self):
+        with TemporaryDirectory() as tmpdir:
+            env_file = Path(tmpdir) / ".env"
+            env_file.write_text("API_SERVER_ENABLED=true\nAPI_SERVER_PORT=8642\n")
+            with (
+                patch.object(server, "ENV_FILE", env_file),
+                patch.dict(
+                    environ,
+                    {"API_SERVER_ENABLED": "true", "API_SERVER_PORT": "9999"},
+                    clear=False,
+                ),
+            ):
+                merged = server.build_hermes_env()
+
+        self.assertEqual(merged["API_SERVER_PORT"], "8642")
+        status = server.evaluate_port_preflight(
+            process_env={"PORT": "8642", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env=merged,
+        )
+        self.assertFalse(status["ok"])
+
+
+class RuntimePreflightTests(unittest.IsolatedAsyncioTestCase):
+    async def test_gateway_does_not_start_when_yaml_api_collision_cannot_be_suppressed(self):
+        gateway = server.Gateway()
+        status = {
+            "ok": False,
+            "api_server_action": "block_gateway_start",
+            "conflicts": [{
+                "services": ["web", "api_server"],
+                "port": 8642,
+            }],
+        }
+
+        with (
+            patch.object(server, "prepare_gateway_env", return_value=({}, status)),
+            patch.object(asyncio, "create_subprocess_exec", new=AsyncMock()) as spawn,
+        ):
+            await gateway.start()
+
+        spawn.assert_not_awaited()
+        self.assertEqual(gateway.state, "error")
+        self.assertIn("config.yaml", gateway.logs[-1])
+
+    async def test_dashboard_does_not_compete_for_public_web_port(self):
+        dashboard = server.Dashboard()
+        conflict = server.evaluate_port_preflight(
+            process_env={"PORT": "9119", "HERMES_DASHBOARD_PORT": "9119"},
+            hermes_env={"API_SERVER_ENABLED": "false"},
+        )
+
+        with (
+            patch.object(server, "evaluate_port_preflight", return_value=conflict),
+            patch.object(asyncio, "create_subprocess_exec", new=AsyncMock()) as spawn,
+        ):
+            await dashboard.start()
+
+        spawn.assert_not_awaited()
+        self.assertIn("Setup remains available", dashboard.logs[-1])
+
+
+class SetupWarningTests(unittest.TestCase):
+    def test_setup_page_renders_port_preflight_warning(self):
+        template = (Path(server.__file__).parent / "templates" / "index.html").read_text()
+
+        self.assertIn("status.port_preflight", template)
+        self.assertIn("Port configuration conflict", template)
+        self.assertIn("conflict.remediation", template)
+        self.assertIn("block_gateway_start", template)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- preflight the public web, native dashboard, and optional Hermes API listener ports
- evaluate the effective Hermes environment, including persisted `.env` values that override Railway variables
- keep messaging alive by suppressing only an environment-enabled conflicting API adapter for that gateway run
- block a YAML-owned API collision instead of mutating persisted configuration or entering a reconnect loop
- show secret-free, actionable remediation in Setup and document listener ownership

This is the Railway port-safety portion of #63, split out so it can be reviewed and merged independently.

## Verification

- 14 focused `unittest` cases in the built Hermes image
- `ruff check --select E9,F63,F7,F82 server.py tests/test_port_preflight.py`
- `python3 -m compileall -q server.py tests/test_port_preflight.py`
- `bash -n start.sh`
- `git diff --check`
- complete Docker image build
- live collision smoke: started with `PORT=9119` and `HERMES_DASHBOARD_PORT=9119`; Setup stayed healthy, the dashboard listener was skipped, and both remediation messages appeared in container logs

## Design boundary

The preflight does not silently choose a free port or rewrite `config.yaml`. Railway routing and persisted Hermes configuration remain operator-owned.
