### PR TITLE
Make admin dashboard responsive on mobile and tablet

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -715,12 +715,114 @@
     font-weight: 500;
   }
   .guide-callout a:hover { text-decoration: underline; }
+
+  /* ── Mobile menu toggle (hamburger) ───────────────── */
+  .menu-toggle {
+    display: none;               /* shown only on narrow viewports */
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    width: 34px;
+    height: 32px;
+    border-radius: 6px;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .menu-toggle:hover { border-color: var(--accent); color: var(--accent); }
+
+  /* Overlay behind the off-canvas drawer */
+  #sidebar-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    z-index: 40;
+    animation: fadeIn 0.15s ease;
+  }
+  @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+  /* ── Responsive: tablet & below ───────────────────── */
+  @media (max-width: 860px) {
+    /* Sidebar becomes an off-canvas drawer */
+    #sidebar {
+      position: fixed;
+      top: var(--header-h);
+      left: 0;
+      bottom: 0;
+      width: 260px;
+      max-width: 82vw;
+      z-index: 50;
+      transform: translateX(-100%);
+      transition: transform 0.2s ease;
+      box-shadow: 2px 0 16px rgba(0,0,0,0.4);
+    }
+    #sidebar.open { transform: translateX(0); }
+    #sidebar-overlay.open { display: block; }
+
+    .menu-toggle { display: inline-flex; }
+
+    /* Reclaim header space: drop the decorative branding block */
+    .header-branding { display: none; }
+    #header { padding: 0 12px; gap: 10px; }
+    .logo { font-size: 15px; }
+    /* Collapse the "Report issue" link to just its icon */
+    .header-issue-link { font-size: 0; padding: 5px 9px; }
+    .header-issue-link::before { content: '⚠'; font-size: 13px; }
+
+    /* Stack the save bar so its buttons never get pushed off-screen */
+    .save-bar {
+      flex-direction: column;
+      align-items: stretch;
+      padding: 12px 16px;
+    }
+    .save-bar > div { justify-content: stretch; }
+    .save-bar .btn { flex: 1; text-align: center; }
+
+    /* Two-column form/status grids collapse to one column */
+    .field-grid-2 { grid-template-columns: 1fr; }
+
+    .panel-header { padding: 14px 16px 10px; }
+    .panel-body { padding: 16px; }
+  }
+
+  /* ── Responsive: phones ───────────────────────────── */
+  @media (max-width: 560px) {
+    :root { --header-h: 48px; }
+
+    #status-label { display: none; }   /* dot still conveys state */
+
+    /* Status page provider/channel columns stack */
+    .status-split { grid-template-columns: 1fr !important; }
+
+    .stat-grid { grid-template-columns: 1fr 1fr; gap: 10px; }
+    .stat-card { padding: 13px; }
+    .stat-value { font-size: 18px; }
+
+    /* Action buttons go full-width and wrap cleanly */
+    .action-row .btn { flex: 1 1 calc(50% - 5px); }
+
+    .template-grid { grid-template-columns: 1fr; }
+
+    .panel-subtitle { display: none; }  /* keep headers compact */
+
+    /* Pair cards stack their actions below the identity */
+    .pair-card { flex-wrap: wrap; }
+
+    #toast { left: 16px; right: 16px; bottom: 16px; max-width: none; }
+  }
 </style>
 </head>
 <body x-data="app()" x-init="init()" x-cloak>
 
 <!-- Header -->
 <div id="header">
+  <button class="menu-toggle" @click="menuOpen = !menuOpen" aria-label="Toggle navigation menu">☰</button>
   <img src="https://pbs.twimg.com/profile_images/1816254738234761216/TX7TW-Mp_400x400.jpg"
        alt="Hermes" style="width:28px;height:28px;border-radius:6px;flex-shrink:0;">
   <div class="logo">hermes<span>/admin</span></div>
@@ -740,8 +842,11 @@
 <!-- Layout -->
 <div id="layout">
 
+  <!-- Backdrop for the off-canvas sidebar (mobile only) -->
+  <div id="sidebar-overlay" :class="{open: menuOpen}" @click="menuOpen = false"></div>
+
   <!-- Sidebar -->
-  <nav id="sidebar">
+  <nav id="sidebar" :class="{open: menuOpen}" @click="menuOpen = false">
 
     <div class="nav-group-label">Setup</div>
     <div class="nav-item" :class="{active: page==='setup'}" @click="page='setup'">
@@ -1210,7 +1315,7 @@
           <button class="btn"         @click="restartGateway()">↺ Restart</button>
         </div>
 
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+        <div class="status-split" style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
           <div>
             <div class="section-label">Providers</div>
             <div class="card" style="padding:0;overflow:hidden;">
@@ -1539,6 +1644,7 @@ function app() {
 
   return {
     page: 'setup',
+    menuOpen: false,
     vars: {},
     gw: {},
     status: {},


### PR DESCRIPTION
The dashboard had no responsive rules: the fixed 220px sidebar ate the width on small screens and right-aligned controls (header Restart, the setup save bar's Save & Start) were pushed off-screen and unreachable.

- Turn the sidebar into an off-canvas drawer below 860px, toggled by a new hamburger button in the header, with a tap-to-dismiss backdrop.
- Compress the header on narrow screens: hide the decorative branding, collapse the Report issue link to its icon, drop the status label on phones (the status dot still conveys state).
- Stack the setup save bar vertically so its buttons stay accessible.
- Collapse two-column form/status grids to one column, shrink stat and template grids, wrap pair-card actions, and full-width the toast.

### Before

<img width="390" height="780" alt="beforemobile" src="https://github.com/user-attachments/assets/ff9a8ce4-3947-4b15-b959-62fd7fefbc98" />

### After these changes

<img width="390" height="780" alt="aftermobilemenu" src="https://github.com/user-attachments/assets/fc91d500-fa95-4beb-9b1a-6155dd7fdb55" />
<img width="390" height="780" alt="aftermobile" src="https://github.com/user-attachments/assets/bab5b653-c36d-466c-bb2e-c57f18108dd0" />

