### PR TITLE
feat: add OpenAI Codex OAuth setup and OAuth-aware gateway startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
-# ── Required: at least one LLM provider key ─────────────────────────────────
+# ── API-key provider example ────────────────────────────────────────────────
+# Not required when OpenAI Codex (ChatGPT subscription) is authorized from
+# /setup. Hermes stores those OAuth credentials only under /data/.hermes/;
+# never paste them into this file or a Railway variable.
 
 # Recommended: OpenRouter (access to all models via one key)
 OPENROUTER_API_KEY=sk-or-...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ release.
 
 ---
 
+## Unreleased — OpenAI Codex OAuth
+
+### Features
+- Added **OpenAI Codex (ChatGPT subscription)** to `/setup`, using Hermes'
+  native `openai-codex` device-code OAuth flow rather than an OpenAI API key.
+- The setup page now shows the verification link, copyable user code,
+  expiration and terminal authorization states, then loads the account's Codex
+  model choices from Hermes. Users can cancel, disconnect, or reauthorize.
+
+### Reliability and security
+- Codex credentials in Hermes' current credential pool and legacy provider
+  token layout are recognized after gateway restarts and Railway redeploys.
+  Readiness fails closed when the model, provider pin, credentials, or YAML
+  configuration is missing or malformed.
+- `write_config_yaml()` preserves dashboard-selected models and providers when
+  `LLM_MODEL` is absent, avoiding blank OAuth configuration on restart.
+- OAuth proxy responses are allowlisted and never expose access/refresh tokens,
+  Hermes session tokens, authorization headers, or raw `auth.json` contents.
+- Documented the persistent `/data` volume requirement and the security impact
+  of storing account credentials in cloud infrastructure and backups.
+
 ## release/v2026.8.3/1 — August 8, 2026
 **Hermes v2026.8.3 · major (Hermes upgrade, from v2026.7.20)**
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ Deploy [Hermes Agent](https://github.com/NousResearch/hermes-agent) on [Railway]
 
 The easiest way to get started:
 
-### 1. Get an LLM Provider Key (free)
+### 1. Choose an LLM provider
 
-1. Register for free at [OpenRouter](https://openrouter.ai/)
-2. Create an API key from your [OpenRouter dashboard](https://openrouter.ai/keys)
-3. Pick a free model from the [model list sorted by price](https://openrouter.ai/models?order=pricing-low-to-high) (e.g. `google/gemma-3-1b-it:free`, `meta-llama/llama-3.1-8b-instruct:free`)
+- **ChatGPT/Codex subscription:** no OpenAI API key is needed. Deploy first, then select **OpenAI Codex (ChatGPT subscription)** on `/setup` and complete the device-code authorization described below.
+- **API key:** for example, register at [OpenRouter](https://openrouter.ai/), create a key, and pick a model from its [model list](https://openrouter.ai/models?order=pricing-low-to-high).
+
+Account and plan access varies. The template does not promise that every ChatGPT plan or account can use every Codex model; the setup page shows the models Hermes reports for the authorized account.
 
 ### 2. Set Up a Telegram Bot (fastest channel)
 
@@ -45,12 +46,12 @@ Hermes Agent interacts entirely through messaging channels — there is no chat 
 
 1. Click the **Deploy on Railway** button above
 2. Set the `ADMIN_PASSWORD` environment variable (or a random one will be generated and printed to deploy logs)
-3. Attach a **volume** mounted at `/data` (persists config across redeploys)
+3. Attach a **persistent volume** mounted at `/data` (required for OAuth credentials and recommended for every deployment)
 4. Open your app URL — log in with username `admin` and your password
 
 ### 4. Configure in the Admin Dashboard
 
-1. **LLM Provider** — select OpenRouter from the dropdown, paste your API key, enter the model name
+1. **LLM Provider** — either select OpenAI Codex and authorize your account, or select an API-key provider and paste its key
 2. **Messaging Channel** — check Telegram, paste the Bot Token from BotFather
 3. Click **Save & Start** — the gateway will start and your bot goes live
 
@@ -76,9 +77,37 @@ All other configuration (LLM provider, model, channels, tools) is managed throug
 
 Selectable from the setup wizard's dropdown:
 
-OpenRouter, Anthropic (Claude), Google AI Studio, xAI (API key **or** SuperGrok OAuth), DeepSeek, Qwen Cloud (DashScope), GLM / Z.AI, Kimi, MiniMax (global **and** China), NVIDIA NIM, Fireworks AI, NovitaAI, Arcee AI, Step Plan, GMI Cloud, Hugging Face, GitHub Copilot, OpenCode Zen, OpenCode Go, Kilo Code, Ollama Cloud, AWS Bedrock, Azure Foundry, and any OpenAI-compatible **Custom Endpoint**.
+OpenAI Codex (ChatGPT subscription OAuth), OpenRouter, Anthropic (Claude), Google AI Studio, xAI (API key **or** SuperGrok OAuth), DeepSeek, Qwen Cloud (DashScope), GLM / Z.AI, Kimi, MiniMax (global **and** China), NVIDIA NIM, Fireworks AI, NovitaAI, Arcee AI, Step Plan, GMI Cloud, Hugging Face, GitHub Copilot, OpenCode Zen, OpenCode Go, Kilo Code, Ollama Cloud, AWS Bedrock, Azure Foundry, and any OpenAI-compatible **Custom Endpoint**.
 
 Every other provider Hermes supports can still be configured from the Hermes Dashboard → **Keys** tab — the wizard covers the common ones, not the limit.
+
+## OpenAI Codex via ChatGPT subscription
+
+This flow uses Hermes' native `openai-codex` provider and ChatGPT device-code authorization. It does **not** use an OpenAI API key, and this Railway wrapper does not implement or store an OAuth client secret.
+
+1. Open `/setup` and select **OpenAI Codex (ChatGPT subscription)**.
+2. Click **Connect OpenAI Codex**.
+3. Use **Open verification page**, then enter the displayed user code. The setup page polls Hermes until the request is approved, denied, canceled, expired, or fails.
+4. After the status changes to **connected**, select one of the Codex models Hermes reports for the authorized account.
+5. Click **Save & Start**. Hermes writes `model.default` and pins `model.provider: openai-codex`; no LLM API key is required.
+
+To switch accounts or recover from an expired code, use **Authorize again**. To remove the authorization, use **Disconnect**; if the gateway is actively using Codex, the template stops it so it cannot continue with credentials already loaded in memory.
+
+Hermes owns the access and refresh tokens and stores them in its normal credential state under `/data/.hermes/`, including `auth.json` and its credential pool. Tokens are never copied to `.env`, Railway variables, browser storage, setup API responses, or logs.
+
+### Persistence and security
+
+Mount a persistent Railway volume at `/data`. With the same volume attached, a gateway restart or redeploy reuses the saved authorization. Without it, `auth.json` and `config.yaml` can be lost and the account must be authorized again.
+
+Treat the service and volume as sensitive infrastructure. Anyone who can access the Railway service, its shell, backups, or the `/data` volume may be able to access account credentials. Restrict Railway project access, use a strong `ADMIN_PASSWORD`, and handle unencrypted template backups as secrets.
+
+### Troubleshooting
+
+- **Code expired:** click **Start authorization again** and use the newest code. Old codes cannot be resumed.
+- **Authorization denied or canceled:** start a new flow when ready.
+- **Codex provider unavailable:** confirm the image is using the pinned/supported Hermes release and wait for the native dashboard to finish starting.
+- **Connected but no models appear:** the authorized account may not expose a compatible Codex model. Reauthorize the intended account and check its plan/model access.
+- **Sent back to `/setup` after a redeploy:** verify the `/data` volume is still mounted at `/data` and contains both `.hermes/config.yaml` and `.hermes/auth.json`. Missing or malformed credentials deliberately make readiness incomplete and prevent a false gateway start.
 
 ## Supported Channels
 

--- a/server.py
+++ b/server.py
@@ -396,7 +396,7 @@ def write_config_yaml(data: dict[str, str], *, reset_model: bool = False) -> Non
     """
     import yaml  # hermes-agent already pulls pyyaml; deferred import keeps cold start light
 
-    model = data.get("LLM_MODEL", "")
+    model = str(data.get("LLM_MODEL") or "").strip()
     config_path = Path(HERMES_HOME) / "config.yaml"
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -407,9 +407,13 @@ def write_config_yaml(data: dict[str, str], *, reset_model: bool = False) -> Non
                 loaded = yaml.safe_load(f)
             if isinstance(loaded, dict):
                 existing = loaded
-        except (yaml.YAMLError, OSError):
-            # Treat unparseable as absent — we'll overwrite with template defaults.
-            existing = {}
+        except (yaml.YAMLError, OSError) as exc:
+            # Never replace a file we could not parse.  In particular, a
+            # transient/partial volume read must not turn a valid OAuth model
+            # selection into a blank template during container startup.
+            raise ValueError("Existing Hermes configuration could not be parsed; fix config.yaml before saving") from exc
+        if not isinstance(loaded, dict):
+            raise ValueError("Existing Hermes configuration must contain a YAML mapping")
 
     merged = dict(existing)
 
@@ -423,7 +427,14 @@ def write_config_yaml(data: dict[str, str], *, reset_model: bool = False) -> Non
         merged_model = {"default": ""}
     else:
         merged_model = dict(merged.get("model") if isinstance(merged.get("model"), dict) else {})
-        merged_model["default"] = model
+        # The native Hermes dashboard writes OAuth model selections directly
+        # to config.yaml and does not need LLM_MODEL in .env.  Preserve that
+        # selection on every gateway restart/redeploy unless the setup form
+        # supplied a real, non-empty replacement.
+        if model:
+            merged_model["default"] = model
+        else:
+            merged_model.setdefault("default", "")
         current_provider = str(merged_model.get("provider") or "").strip()
         # Only default to "auto" on a config that has never had a provider
         # pinned. Once a provider is set explicitly — either by
@@ -622,17 +633,78 @@ _XAI_GRANT_TYPE  = "urn:ietf:params:oauth:grant-type:device_code"
 _xai_oauth_state: dict | None = None  # one auth at a time (single-user deployment)
 
 
-def _has_xai_oauth_tokens() -> bool:
-    """True when auth.json contains a valid xAI OAuth refresh token."""
+def _read_auth_json() -> dict:
+    """Read Hermes' credential store without ever logging its contents."""
     auth_path = Path(HERMES_HOME) / "auth.json"
     if not auth_path.exists():
-        return False
+        return {}
     try:
-        data = json.loads(auth_path.read_text())
-        tokens = data.get("providers", {}).get("xai-oauth", {}).get("tokens", {})
-        return bool(isinstance(tokens, dict) and tokens.get("refresh_token"))
+        loaded = json.loads(auth_path.read_text())
+        return loaded if isinstance(loaded, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _has_xai_oauth_tokens() -> bool:
+    """True when auth.json contains a valid xAI OAuth refresh token."""
+    providers = _read_auth_json().get("providers")
+    state = providers.get("xai-oauth") if isinstance(providers, dict) else None
+    tokens = state.get("tokens") if isinstance(state, dict) else None
+    return bool(isinstance(tokens, dict) and tokens.get("refresh_token"))
+
+
+def _codex_credentials_in_auth_json(data: dict | None = None) -> bool:
+    """Recognize current and legacy Hermes Codex OAuth credential layouts.
+
+    Hermes v2026.8.3 resolves inference credentials from
+    ``credential_pool.openai-codex`` and retains the singleton provider state
+    at ``providers.openai-codex.tokens``.  The official status helper is the
+    primary readiness check; this shape-only reader is a fail-closed fallback
+    for early startup/import failures and older persisted volumes.
+    """
+    data = data if isinstance(data, dict) else _read_auth_json()
+    pool = data.get("credential_pool")
+    entries = pool.get("openai-codex") if isinstance(pool, dict) else None
+    if isinstance(entries, list):
+        for entry in entries:
+            if not isinstance(entry, dict) or entry.get("last_status") == "dead":
+                continue
+            access = str(entry.get("access_token") or "").strip()
+            refresh = str(entry.get("refresh_token") or "").strip()
+            if access and refresh:
+                return True
+
+    providers = data.get("providers")
+    state = providers.get("openai-codex") if isinstance(providers, dict) else None
+    tokens = state.get("tokens") if isinstance(state, dict) else None
+    return bool(
+        isinstance(tokens, dict)
+        and str(tokens.get("access_token") or "").strip()
+        and str(tokens.get("refresh_token") or "").strip()
+    )
+
+
+def _codex_status_from_hermes() -> bool | None:
+    """Use Hermes' official status resolver when it can be imported safely.
+
+    ``None`` means the helper was unavailable or failed before it could
+    determine state; only then do callers use the conservative on-disk
+    compatibility check above.
+    """
+    try:
+        from hermes_cli.auth import get_codex_auth_status
+    except (ImportError, ModuleNotFoundError):
+        return None
+    try:
+        status = get_codex_auth_status()
     except Exception:
-        return False
+        return None
+    return bool(isinstance(status, dict) and status.get("logged_in"))
+
+
+def _has_codex_oauth_credentials() -> bool:
+    official = _codex_status_from_hermes()
+    return official if official is not None else _codex_credentials_in_auth_json()
 
 
 def _save_xai_auth_json(tokens: dict) -> None:
@@ -854,6 +926,32 @@ async def api_oauth_xai_status(request: Request) -> Response:
     })
 
 
+def _configured_model_from_yaml() -> tuple[str, str, bool]:
+    """Return ``(model, provider, parsed)`` from config.yaml.
+
+    A missing file is a valid empty configuration.  A present but malformed
+    file is not: readiness must fail instead of guessing and starting the
+    gateway against a partially-read configuration.
+    """
+    import yaml
+
+    config_path = Path(HERMES_HOME) / "config.yaml"
+    if not config_path.exists():
+        return "", "", True
+    try:
+        loaded = yaml.safe_load(config_path.read_text())
+    except (OSError, yaml.YAMLError):
+        return "", "", False
+    if not isinstance(loaded, dict):
+        return "", "", False
+    model_cfg = loaded.get("model")
+    if not isinstance(model_cfg, dict):
+        return "", "", True
+    model = str(model_cfg.get("default") or model_cfg.get("name") or "").strip()
+    provider = str(model_cfg.get("provider") or "").strip().lower()
+    return model, provider, True
+
+
 def is_config_complete(data: dict[str, str] | None = None) -> bool:
     """Single source of truth for 'ready to run the gateway'.
 
@@ -861,9 +959,29 @@ def is_config_complete(data: dict[str, str] | None = None) -> bool:
     """
     if data is None:
         data = read_env(ENV_FILE)
-    has_model = bool(data.get("LLM_MODEL"))
-    has_provider = any(data.get(k) for k in PROVIDER_KEYS) or _has_xai_oauth_tokens()
-    return has_model and has_provider
+    yaml_model, yaml_provider, parsed = _configured_model_from_yaml()
+    if not parsed:
+        return False
+
+    env_model = str(data.get("LLM_MODEL") or "").strip()
+    selected_model = yaml_model or env_model
+    if not selected_model:
+        return False
+
+    # Explicit OAuth routing is fail-closed: another unrelated API key must
+    # not make an openai-codex/xai-oauth selection look ready after its own
+    # persisted credentials were removed or malformed.
+    if yaml_provider == "openai-codex":
+        return _has_codex_oauth_credentials()
+    if yaml_provider == "xai-oauth":
+        return _has_xai_oauth_tokens()
+
+    if any(data.get(k) for k in PROVIDER_KEYS):
+        return True
+
+    # Backward compatibility for the template's older xAI flow, which wrote
+    # LLM_MODEL before every deployment had an explicit provider pin.
+    return bool(_has_xai_oauth_tokens())
 
 
 def mask(data: dict[str, str]) -> dict[str, str]:
@@ -1086,6 +1204,10 @@ class Gateway:
     async def start(self, *, reset_budget: bool = True):
         if self.proc and self.proc.returncode is None:
             return
+        if not is_config_complete():
+            self.state = "stopped"
+            self.logs.append("[gateway] start skipped — provider/model not configured")
+            return
         # A manual Start/Restart (or boot) grants a fresh crash-loop budget; the
         # auto-respawn path passes reset_budget=False so repeated crashes keep
         # accumulating toward the give-up threshold.
@@ -1095,9 +1217,11 @@ class Gateway:
         self._stopping = False
         try:
             env = build_hermes_env()
-            model = env.get("LLM_MODEL", "")
+            yaml_model, yaml_provider, _ = _configured_model_from_yaml()
+            model = yaml_model or env.get("LLM_MODEL", "")
             provider_key = next((env.get(k, "") for k in PROVIDER_KEYS if env.get(k)), "")
-            print(f"[gateway] model={model or '⚠ NOT SET'} | provider_key={'set' if provider_key else '⚠ NOT SET'}", flush=True)
+            auth_kind = yaml_provider or ("api-key" if provider_key else "not-set")
+            print(f"[gateway] model={model or '⚠ NOT SET'} | provider={auth_kind}", flush=True)
             # Write config.yaml so hermes picks up the model (env vars alone aren't always enough)
             write_config_yaml(read_env(ENV_FILE))
             # --replace: force-displace any existing gateway.pid lock holder
@@ -1461,6 +1585,295 @@ async def set_active_model_via_hermes(
     return None
 
 
+# ── Native Hermes OpenAI Codex OAuth bridge ─────────────────────────────────
+# The pinned Hermes dashboard owns the OAuth client, device-code exchange,
+# refresh lifecycle, and credential persistence.  These wrappers only attach
+# Hermes' server-side session token and project an allowlisted, non-secret
+# response shape for the setup page.
+class HermesProxyError(Exception):
+    def __init__(self, message: str, status_code: int = 503):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
+async def _hermes_api_json(
+    method: str,
+    path: str,
+    *,
+    json_body: dict | None = None,
+    timeout: float = 20.0,
+) -> dict:
+    """Call one allowlisted local Hermes API path with its session token."""
+    if not path.startswith("/api/") or "\n" in path or "\r" in path:
+        raise HermesProxyError("Invalid Hermes API path.", 500)
+    try:
+        session_token = await _get_hermes_session_token()
+    except Exception as exc:
+        raise HermesProxyError(
+            "The native Hermes dashboard is not available yet. Wait a moment and try again."
+        ) from exc
+    if not session_token:
+        raise HermesProxyError(
+            "Hermes started, but its dashboard session token could not be obtained. Restart the service and try again."
+        )
+
+    try:
+        response = await get_http_client().request(
+            method,
+            f"{HERMES_DASHBOARD_URL}{path}",
+            json=json_body,
+            headers={_SESSION_TOKEN_HEADER: session_token},
+            timeout=httpx.Timeout(timeout),
+        )
+    except httpx.RequestError as exc:
+        raise HermesProxyError(
+            "The native Hermes dashboard could not be reached. Wait for it to finish starting and try again."
+        ) from exc
+
+    if response.status_code == 404:
+        raise HermesProxyError(
+            "OpenAI Codex OAuth is unavailable in this Hermes version.", 409
+        )
+    if response.status_code in {401, 403}:
+        raise HermesProxyError(
+            "Hermes rejected the internal dashboard session. Restart the service and try again."
+        )
+    if response.status_code >= 400:
+        # Never forward the upstream response body: provider and validation
+        # errors can contain token-shaped values, URLs, or auth-store paths.
+        raise HermesProxyError(
+            "Hermes could not complete the OAuth request. Check the account settings and try again.",
+            502 if response.status_code >= 500 else 400,
+        )
+    try:
+        payload = response.json()
+    except Exception as exc:
+        raise HermesProxyError("Hermes returned an invalid OAuth response.", 502) from exc
+    if not isinstance(payload, dict):
+        raise HermesProxyError("Hermes returned an invalid OAuth response.", 502)
+    return payload
+
+
+def _proxy_error_response(exc: HermesProxyError) -> JSONResponse:
+    return JSONResponse({"error": exc.message}, status_code=exc.status_code)
+
+
+def _codex_provider_from_catalog(payload: dict) -> dict | None:
+    providers = payload.get("providers")
+    if not isinstance(providers, list):
+        return None
+    return next(
+        (
+            row for row in providers
+            if isinstance(row, dict) and row.get("id") == "openai-codex"
+        ),
+        None,
+    )
+
+
+def _codex_status_public(payload: dict) -> dict:
+    provider = _codex_provider_from_catalog(payload)
+    model, selected_provider, _ = _configured_model_from_yaml()
+    if provider is None:
+        return {
+            "available": False,
+            "connected": False,
+            "status": "error",
+            "model": model if selected_provider == "openai-codex" else "",
+            "error": "OpenAI Codex OAuth is unavailable in this Hermes version.",
+        }
+    raw_status = provider.get("status")
+    connected = bool(isinstance(raw_status, dict) and raw_status.get("logged_in"))
+    return {
+        "available": True,
+        "connected": connected,
+        "status": "connected" if connected else "not_connected",
+        "model": model if selected_provider == "openai-codex" else "",
+    }
+
+
+_OAUTH_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]{8,128}$")
+_OAUTH_STATUS_MAP = {
+    "pending": "waiting",
+    "approved": "connected",
+    "denied": "denied",
+    "expired": "expired",
+    "cancelled": "canceled",
+    "canceled": "canceled",
+    "error": "error",
+}
+
+
+def _valid_oauth_session_id(session_id: str) -> bool:
+    return bool(_OAUTH_SESSION_ID_RE.fullmatch(session_id or ""))
+
+
+def _safe_oauth_status_message(status: str) -> str:
+    return {
+        "denied": "Authorization was denied. Start again when you are ready.",
+        "expired": "The device code expired. Start authorization again to get a new code.",
+        "canceled": "Authorization was canceled.",
+        "error": "Hermes could not complete authorization. Try again; if it repeats, check the service logs.",
+    }.get(status, "")
+
+
+async def api_oauth_codex_status(request: Request) -> Response:
+    if err := guard(request):
+        return err
+    try:
+        payload = await _hermes_api_json("GET", "/api/providers/oauth")
+        return JSONResponse(_codex_status_public(payload))
+    except HermesProxyError as exc:
+        return _proxy_error_response(exc)
+
+
+async def api_oauth_codex_start(request: Request) -> Response:
+    if err := guard(request):
+        return err
+    try:
+        payload = await _hermes_api_json(
+            "POST", "/api/providers/oauth/openai-codex/start", json_body={}
+        )
+    except HermesProxyError as exc:
+        return _proxy_error_response(exc)
+
+    session_id = str(payload.get("session_id") or "")
+    user_code = str(payload.get("user_code") or "")
+    verification_url = str(payload.get("verification_url") or "")
+    parsed_verification_url = _urlparse(verification_url)
+    if (
+        not _valid_oauth_session_id(session_id)
+        or not re.fullmatch(r"[A-Za-z0-9-]{3,64}", user_code)
+        or parsed_verification_url.scheme != "https"
+        or parsed_verification_url.hostname != "auth.openai.com"
+    ):
+        return JSONResponse({"error": "Hermes returned an incomplete device-code response."}, status_code=502)
+    try:
+        expires_in = max(0, int(payload.get("expires_in") or 0))
+        poll_interval = min(30, max(2, int(payload.get("poll_interval") or 5)))
+    except (TypeError, ValueError):
+        expires_in, poll_interval = 0, 5
+    return JSONResponse({
+        "session_id": session_id,
+        "user_code": user_code,
+        "verification_url": verification_url,
+        "status": "waiting",
+        "expires_at": time.time() + expires_in if expires_in else None,
+        "poll_interval": poll_interval,
+    })
+
+
+async def api_oauth_codex_poll(request: Request) -> Response:
+    if err := guard(request):
+        return err
+    session_id = request.path_params.get("session_id", "")
+    if not _valid_oauth_session_id(session_id):
+        return JSONResponse({"error": "Invalid OAuth session."}, status_code=400)
+    try:
+        payload = await _hermes_api_json(
+            "GET", f"/api/providers/oauth/openai-codex/poll/{session_id}"
+        )
+    except HermesProxyError as exc:
+        return _proxy_error_response(exc)
+    status = _OAUTH_STATUS_MAP.get(str(payload.get("status") or "").lower(), "error")
+    public = {
+        "session_id": session_id,
+        "status": status,
+        "expires_at": payload.get("expires_at") if isinstance(payload.get("expires_at"), (int, float)) else None,
+    }
+    message = _safe_oauth_status_message(status)
+    if message:
+        public["error"] = message
+    return JSONResponse(public)
+
+
+async def api_oauth_codex_cancel(request: Request) -> Response:
+    if err := guard(request):
+        return err
+    session_id = request.path_params.get("session_id", "")
+    if not _valid_oauth_session_id(session_id):
+        return JSONResponse({"error": "Invalid OAuth session."}, status_code=400)
+    try:
+        payload = await _hermes_api_json(
+            "DELETE", f"/api/providers/oauth/sessions/{session_id}"
+        )
+    except HermesProxyError as exc:
+        return _proxy_error_response(exc)
+    return JSONResponse({
+        "ok": bool(payload.get("ok")),
+        "session_id": session_id,
+        "status": "canceled",
+    })
+
+
+async def api_oauth_codex_disconnect(request: Request) -> Response:
+    if err := guard(request):
+        return err
+    try:
+        payload = await _hermes_api_json(
+            "DELETE", "/api/providers/oauth/openai-codex"
+        )
+    except HermesProxyError as exc:
+        return _proxy_error_response(exc)
+    _, selected_provider, _ = _configured_model_from_yaml()
+    if selected_provider == "openai-codex":
+        await gw.stop()
+    return JSONResponse({
+        "ok": bool(payload.get("ok")),
+        "status": "not_connected",
+    })
+
+
+def _codex_models_public(payload: dict) -> list[str]:
+    providers = payload.get("providers")
+    if not isinstance(providers, list):
+        return []
+    row = next((
+        item for item in providers
+        if isinstance(item, dict) and str(item.get("slug") or "").lower() == "openai-codex"
+    ), None)
+    if row is None:
+        return []
+    unavailable = {
+        str(item) for item in (row.get("unavailable_models") or [])
+        if isinstance(item, str)
+    }
+    models: list[str] = []
+    for item in row.get("models") or []:
+        model = item if isinstance(item, str) else item.get("id") if isinstance(item, dict) else ""
+        model = str(model or "").strip()
+        if (
+            model
+            and re.fullmatch(r"[A-Za-z0-9._:/-]{1,200}", model)
+            and model not in unavailable
+            and model not in models
+        ):
+            models.append(model)
+    return models
+
+
+async def api_oauth_codex_models(request: Request) -> Response:
+    if err := guard(request):
+        return err
+    if not _has_codex_oauth_credentials():
+        return JSONResponse({
+            "error": "OpenAI Codex is not connected. Complete authorization before loading models."
+        }, status_code=409)
+    try:
+        payload = await _hermes_api_json(
+            "GET", "/api/model/options?explicit_only=true"
+        )
+    except HermesProxyError as exc:
+        return _proxy_error_response(exc)
+    models = _codex_models_public(payload)
+    if not models:
+        return JSONResponse({
+            "error": "Authorization succeeded, but Hermes found no compatible Codex models for this account."
+        }, status_code=409)
+    return JSONResponse({"provider": "openai-codex", "models": models})
+
+
 # ── Route handlers ────────────────────────────────────────────────────────────
 async def page_index(request: Request):
     if err := guard(request): return err
@@ -1476,7 +1889,16 @@ async def api_config_get(request: Request):
     async with cfg_lock:
         data = read_env(ENV_FILE)
     defs = [{"key": k, "label": l, "category": c, "secret": s} for k, l, c, s in ENV_VARS]
-    return JSONResponse({"vars": mask(data), "defs": defs})
+    model, provider, parsed = _configured_model_from_yaml()
+    return JSONResponse({
+        "vars": mask(data),
+        "defs": defs,
+        "config_complete": is_config_complete(data),
+        "model_config": {
+            "model": model if parsed else "",
+            "provider": provider if parsed else "",
+        },
+    })
 
 
 async def api_config_put(request: Request):
@@ -1492,6 +1914,9 @@ async def api_config_put(request: Request):
         # — empty when the user saved without touching a provider (e.g. just
         # toggling a messaging channel). See set_active_model_via_hermes().
         active_provider_key = str(body.pop("_active_provider_key", "") or "").strip()
+        active_oauth_provider = str(body.pop("_active_oauth_provider", "") or "").strip().lower()
+        if active_oauth_provider not in {"", "openai-codex"}:
+            return JSONResponse({"error": "Unsupported OAuth provider."}, status_code=400)
         new_vars = body.get("vars", {})
         async with cfg_lock:
             existing = read_env(ENV_FILE)
@@ -1499,12 +1924,33 @@ async def api_config_put(request: Request):
             for k, v in existing.items():
                 if k not in merged:
                     merged[k] = v
-            write_env(ENV_FILE, merged)
+
+        model_value = str(merged.get("LLM_MODEL") or "").strip()
+        if active_oauth_provider == "openai-codex":
+            if not model_value:
+                return JSONResponse({"error": "Select a Codex model before saving."}, status_code=400)
+            if not _has_codex_oauth_credentials():
+                return JSONResponse({
+                    "error": "OpenAI Codex is not connected. Complete authorization before saving."
+                }, status_code=409)
+            # For Codex, an explicit provider pin is mandatory.  Apply it via
+            # Hermes before mutating .env so a dashboard failure cannot leave
+            # behind a false configured state.
+            pin_warning = await set_active_model_via_hermes(
+                "openai-codex", model_value
+            )
+            if pin_warning:
+                return JSONResponse({
+                    "error": "Hermes could not save the Codex model. Wait for the dashboard to finish starting and try again."
+                }, status_code=503)
+            merged["_MODEL_OPENAI_CODEX"] = model_value
+
+        async with cfg_lock:
             write_config_yaml(merged)
+            write_env(ENV_FILE, merged)
 
         model_warning = None
         hermes_provider_id = HERMES_PROVIDER_IDS.get(active_provider_key)
-        model_value = merged.get("LLM_MODEL", "").strip()
         if hermes_provider_id and model_value:
             pin_base_url = ""
             pin_api_key = ""
@@ -1518,13 +1964,13 @@ async def api_config_put(request: Request):
                 hermes_provider_id, model_value, base_url=pin_base_url, api_key=pin_api_key
             )
 
-        if restart:
+        if restart and is_config_complete(merged):
             asyncio.create_task(gw.restart())
             # The dashboard (and its embedded Chat tab) only ever sees the env
             # it was spawned with — a newly-saved provider key doesn't reach
             # the already-running process otherwise. See Dashboard.restart().
             asyncio.create_task(dash.restart())
-        resp = {"ok": True, "restarting": restart}
+        resp = {"ok": True, "restarting": bool(restart and is_config_complete(merged))}
         if model_warning:
             resp["warning"] = model_warning
         return JSONResponse(resp)
@@ -1544,6 +1990,9 @@ async def api_status(request: Request):
         {"configured": bool(data.get(k))}
         for k in PROVIDER_KEYS
     }
+    providers["OpenAI Codex (ChatGPT subscription)"] = {
+        "configured": _has_codex_oauth_credentials()
+    }
     channels = {
         name: {"configured": bool(v := data.get(key,"")) and v.lower() not in ("false","0","no")}
         for name, key in CHANNEL_MAP.items()
@@ -1559,6 +2008,8 @@ async def api_logs(request: Request):
 
 async def api_gw_start(request: Request):
     if err := guard(request): return err
+    if not is_config_complete():
+        return JSONResponse({"error": "Provider, model, or authorization is incomplete."}, status_code=409)
     asyncio.create_task(gw.start())
     return JSONResponse({"ok": True})
 
@@ -1571,6 +2022,8 @@ async def api_gw_stop(request: Request):
 
 async def api_gw_restart(request: Request):
     if err := guard(request): return err
+    if not is_config_complete():
+        return JSONResponse({"error": "Provider, model, or authorization is incomplete."}, status_code=409)
     asyncio.create_task(gw.restart())
     return JSONResponse({"ok": True})
 
@@ -2396,6 +2849,12 @@ routes = [
     Route("/setup/api/oauth/xai/start",         api_oauth_xai_start,  methods=["POST"]),
     Route("/setup/api/oauth/xai/status",        api_oauth_xai_status),
     Route("/setup/api/oauth/xai",               api_oauth_xai_delete, methods=["DELETE"]),
+    Route("/setup/api/oauth/codex",             api_oauth_codex_status, methods=["GET"]),
+    Route("/setup/api/oauth/codex",             api_oauth_codex_disconnect, methods=["DELETE"]),
+    Route("/setup/api/oauth/codex/start",       api_oauth_codex_start, methods=["POST"]),
+    Route("/setup/api/oauth/codex/models",      api_oauth_codex_models, methods=["GET"]),
+    Route("/setup/api/oauth/codex/poll/{session_id}", api_oauth_codex_poll, methods=["GET"]),
+    Route("/setup/api/oauth/codex/sessions/{session_id}", api_oauth_codex_cancel, methods=["DELETE"]),
     Route("/setup/api/backup/download",         api_backup_download),
     Route("/setup/api/backup/restore",          api_backup_restore,  methods=["POST"]),
     Route("/setup/api/backup/snapshots",        api_backup_snapshots),

--- a/templates/index.html
+++ b/templates/index.html
@@ -1135,7 +1135,7 @@
         </div>
         <div class="card">
           <p class="hint" style="margin:0 0 12px;line-height:1.55;">
-            Select a provider, paste its key and enter a model, then click <strong>Save &amp; Start</strong>.
+            Select a provider, add its API key or connect an account, choose a model, then click <strong>Save &amp; Start</strong>.
             You can add multiple providers — each saves alongside the others.
             Configured providers appear in the list below with a Remove button.
             Every provider Hermes supports is also manageable from the
@@ -1206,7 +1206,7 @@
             </div>
           </template>
 
-          <div class="field-gap" x-show="selectedProvider">
+          <div class="field-gap" x-show="selectedProvider && providerMap[selectedProvider]?.isOauth !== 'codex'">
             <label class="field-label">LLM Model</label>
             <input type="text" :value="vars.LLM_MODEL||''" @input="vars.LLM_MODEL=$event.target.value"
                    :placeholder="selectedProvider === 'xAI Grok (SuperGrok)' || selectedProvider === 'xAI' ? 'e.g. grok-4.3'
@@ -1223,6 +1223,68 @@
             <p class="hint" x-show="selectedProvider === 'MiniMax' || selectedProvider === 'MiniMax (China)'">e.g. <code>MiniMax-M3</code>, <code>MiniMax-M2.7</code></p>
             <p class="hint" x-show="!['xAI Grok (SuperGrok)','xAI','Anthropic (Claude)','AWS Bedrock','Fireworks AI','MiniMax','MiniMax (China)','Custom Endpoint','Azure Foundry'].includes(selectedProvider) && selectedProvider">Check your provider's docs for model names. OpenRouter format: <code>provider/model-name</code></p>
           </div>
+        </div>
+
+        <!-- OpenAI Codex OAuth — delegated to the pinned Hermes dashboard -->
+        <div class="card" x-show="selectedProvider === 'OpenAI Codex (ChatGPT subscription)'" style="border-left:3px solid #10a37f;padding:14px 16px;">
+          <p style="margin:0 0 10px;font-size:13px;font-weight:600;color:#c9d1d9;">OpenAI Codex — ChatGPT subscription</p>
+          <p class="hint" style="margin:0 0 12px;line-height:1.5;">
+            Hermes will authorize this deployment with your ChatGPT/Codex account using a device code. No OpenAI API key is required.
+          </p>
+
+          <template x-if="codex.status === 'not_connected'">
+            <button class="btn primary" style="width:100%;" @click="startCodexOauth()">
+              Connect OpenAI Codex
+            </button>
+          </template>
+
+          <template x-if="codex.status === 'starting'">
+            <p class="hint" style="margin:0;">Starting authorization…</p>
+          </template>
+
+          <template x-if="codex.status === 'waiting'">
+            <div>
+              <p class="hint" style="margin:0 0 10px;">Open the verification page, enter this code, then return here. This page will keep checking automatically.</p>
+              <div style="display:flex;gap:8px;margin-bottom:10px;">
+                <a class="btn primary" style="flex:1;text-align:center;text-decoration:none;" :href="codex.verificationUrl" target="_blank" rel="noopener">Open verification page</a>
+                <button class="btn" style="flex:0 0 auto;" @click="copyCodexCode()">Copy code</button>
+              </div>
+              <div style="background:var(--surface2);border:1px solid var(--border);border-radius:6px;padding:14px;text-align:center;margin-bottom:10px;">
+                <span style="font-family:var(--font-mono);font-size:26px;letter-spacing:5px;color:#c9d1d9;" x-text="codex.userCode"></span>
+              </div>
+              <p class="hint" style="margin:0 0 10px;">Status: waiting for authorization<span x-show="codex.expiresAt"> · expires <span x-text="formatCodexExpiry()"></span></span></p>
+              <button class="btn" style="width:100%;" @click="cancelCodexOauth()">Cancel authorization</button>
+            </div>
+          </template>
+
+          <template x-if="codex.status === 'connected'">
+            <div>
+              <p style="color:var(--green);font-size:13px;margin:0 0 10px;">✓ OpenAI Codex connected</p>
+              <label class="field-label">Codex model</label>
+              <select x-model="vars.LLM_MODEL" @change="vars._MODEL_OPENAI_CODEX=$event.target.value" :disabled="codex.modelsLoading">
+                <option value="" x-text="codex.modelsLoading ? 'Loading models…' : '— Select a Codex model —'"></option>
+                <template x-for="model in codex.models" :key="model">
+                  <option :value="model" x-text="model"></option>
+                </template>
+              </select>
+              <p class="hint" x-show="codex.modelsError" x-text="codex.modelsError" style="color:var(--red);margin:8px 0 0;"></p>
+              <div style="display:flex;gap:8px;margin-top:10px;">
+                <button class="btn" style="flex:1;" @click="startCodexOauth()">Authorize again</button>
+                <button class="btn danger" style="flex:1;" @click="disconnectCodex()">Disconnect</button>
+              </div>
+            </div>
+          </template>
+
+          <template x-if="['denied','expired','canceled','error'].includes(codex.status)">
+            <div>
+              <p style="color:var(--red);font-size:13px;margin:0 0 8px;" x-text="codex.error || 'Authorization did not complete.'"></p>
+              <button class="btn primary" style="width:100%;" @click="startCodexOauth()">Start authorization again</button>
+            </div>
+          </template>
+
+          <template x-if="codex.status === 'disconnecting'">
+            <p class="hint" style="margin:0;">Disconnecting OpenAI Codex…</p>
+          </template>
         </div>
 
         <!-- xAI Grok SuperGrok OAuth — shown when xAI provider is selected -->
@@ -1736,7 +1798,7 @@
               <span class="step-note">Browse all available models at <a href="https://openrouter.ai/models" target="_blank" rel="noopener">openrouter.ai/models</a> — filter by "Free" to see no-cost options.</span>
             </li>
             <li>
-              Head over to the <strong>Setup</strong> page (left sidebar), select <strong>OpenRouter</strong> as provider, paste your API key, and enter the model name.
+              Head over to the <strong>Setup</strong> page (left sidebar). You can select <strong>OpenAI Codex (ChatGPT subscription)</strong> and authorize with a device code, or select <strong>OpenRouter</strong>, paste your API key, and enter the model name.
               <span class="step-note">
                 Want a different provider (Anthropic, DeepSeek, Groq, Cerebras, Mistral, etc.)? Open the
                 <a href="/?force=1" style="color:var(--accent2);">Hermes Dashboard</a> from the sidebar — the
@@ -1807,6 +1869,22 @@
             template-only fixes and improvements on top of it — the Hermes version never changes within a series.
             <strong style="color:var(--text);">Pick the highest number</strong> for the Hermes version you want; each branch stays put once published.
           </div>
+        </div>
+
+        <div class="changelog-entry major">
+          <div class="changelog-date">Unreleased</div>
+          <div class="changelog-meta">
+            <span class="meta-box version">
+              <span class="meta-label">Hermes compatible version</span>
+              <code>v2026.8.3</code>
+            </span>
+          </div>
+          <div class="changelog-group">OpenAI Codex OAuth</div>
+          <ul class="changelog-list">
+            <li><strong>ChatGPT subscription setup is now native to /setup.</strong> Connect OpenAI Codex with a device code, follow authorization status in the page, choose a model reported by Hermes, then Save &amp; Start without an OpenAI API key.</li>
+            <li><strong>Authorization survives restarts and redeploys</strong> when the persistent <code>/data</code> volume remains attached. Missing credentials now stop readiness instead of falsely starting the gateway.</li>
+            <li><strong>OAuth secrets stay inside Hermes.</strong> The setup bridge exposes only the user code, verification URL, status, expiry, and model IDs — never access tokens, refresh tokens, or the Hermes dashboard session token.</li>
+          </ul>
         </div>
 
         <div class="changelog-entry major">
@@ -2039,10 +2117,16 @@ function app() {
       'Ollama Cloud':         { key: 'OLLAMA_API_KEY',           modelKey: '_MODEL_OLLAMA_API_KEY',           placeholder: '' },
       'Azure Foundry':        { key: 'AZURE_FOUNDRY_API_KEY',   modelKey: '_MODEL_AZURE_FOUNDRY_API_KEY',   placeholder: '', isAzure: true },
       'Custom Endpoint':      { key: 'CUSTOM_PROVIDER_API_KEY',modelKey: '_MODEL_CUSTOM_PROVIDER_API_KEY',placeholder: '',         isCustom: true },
+      'OpenAI Codex (ChatGPT subscription)': { key: null, modelKey: '_MODEL_OPENAI_CODEX', isOauth: 'codex' },
       'xAI Grok (SuperGrok)': { key: null,                     modelKey: '_MODEL_XAI_OAUTH',              isOauth: 'xai' },
     },
 
     xai: { loading: false, userCode: '', verificationUri: '', status: 'none', error: '' },
+    codex: {
+      status: 'not_connected', available: true, sessionId: '', userCode: '',
+      verificationUrl: '', expiresAt: null, pollTimer: null, pollInterval: 5,
+      error: '', models: [], modelsLoading: false, modelsError: '',
+    },
 
     selectedProvider: '',
 
@@ -2058,7 +2142,11 @@ function app() {
     get configuredProviders() {
       const list = [];
       for (const [name, p] of Object.entries(this.providerMap)) {
-        if (p.isOauth === 'xai') {
+        if (p.isOauth === 'codex') {
+          if (this.codex.status === 'connected') {
+            list.push({ providerKey: name, name, model: this.vars._MODEL_OPENAI_CODEX || '', isOauth: true });
+          }
+        } else if (p.isOauth === 'xai') {
           if (this.xai.status === 'authorized') {
             list.push({ providerKey: name, name, model: this.vars['_MODEL_XAI_OAUTH'] || '', isOauth: true });
           }
@@ -2075,7 +2163,7 @@ function app() {
     },
 
     get isSetupDone() {
-      return this.configuredProviders.length > 0 && !!this.vars.LLM_MODEL;
+      return this.savedConfigComplete || (this.configuredProviders.length > 0 && !!this.vars.LLM_MODEL);
     },
 
     onProviderChange() {
@@ -2084,6 +2172,10 @@ function app() {
       // Load the per-provider stored model so the model field pre-fills.
       const storedModel = p.modelKey ? this.vars[p.modelKey] : null;
       if (storedModel) this.vars.LLM_MODEL = storedModel;
+      if (p.isOauth === 'codex') this.loadCodexStatus();
+      if (p.isOauth !== 'codex' && this.codex.status === 'waiting') {
+        this.cancelCodexOauth(false);
+      }
       // Reset xAI flow state if switching away (unless already fully authorized).
       if (p.isOauth !== 'xai' && this.xai.status !== 'authorized') {
         this.xai.status = 'none';
@@ -2100,6 +2192,9 @@ function app() {
       if (p.isOauth === 'xai') {
         await fetch('/setup/api/oauth/xai', { method: 'DELETE' });
         this.xai.status = 'none';
+      }
+      if (p.isOauth === 'codex') {
+        await this.disconnectCodex(false);
       }
       if (p.key)      this.vars[p.key]      = '';
       if (p.modelKey) this.vars[p.modelKey] = '';
@@ -2144,6 +2239,181 @@ function app() {
       if (t.key === 'BROWSERBASE_API_KEY') this.vars.BROWSERBASE_PROJECT_ID = '';
     },
 
+    stopCodexPolling() {
+      if (this.codex.pollTimer) clearTimeout(this.codex.pollTimer);
+      this.codex.pollTimer = null;
+    },
+
+    async loadCodexStatus() {
+      try {
+        const r = await fetch('/setup/api/oauth/codex');
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) {
+          this.codex.status = 'error';
+          this.codex.error = d.error || 'Could not read OpenAI Codex authorization status.';
+          return;
+        }
+        this.codex.available = d.available !== false;
+        this.codex.status = d.status || (d.connected ? 'connected' : 'not_connected');
+        this.codex.error = d.error || '';
+        if (d.model) {
+          this.vars._MODEL_OPENAI_CODEX = d.model;
+          if (!this.vars.LLM_MODEL) this.vars.LLM_MODEL = d.model;
+        }
+        if (this.codex.status === 'connected' && this.codex.models.length === 0) {
+          await this.loadCodexModels();
+        }
+      } catch (e) {
+        this.codex.status = 'error';
+        this.codex.error = 'Could not reach the setup server.';
+      }
+    },
+
+    async startCodexOauth() {
+      if (this.codex.sessionId) await this.cancelCodexOauth(false);
+      this.stopCodexPolling();
+      this.codex.status = 'starting';
+      this.codex.error = '';
+      this.codex.modelsError = '';
+      try {
+        const r = await fetch('/setup/api/oauth/codex/start', { method: 'POST' });
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) {
+          this.codex.status = 'error';
+          this.codex.error = d.error || 'Could not start OpenAI Codex authorization.';
+          return;
+        }
+        this.codex.sessionId = d.session_id;
+        this.codex.userCode = d.user_code;
+        this.codex.verificationUrl = d.verification_url;
+        this.codex.expiresAt = d.expires_at;
+        this.codex.pollInterval = d.poll_interval || 5;
+        this.codex.status = 'waiting';
+        this.scheduleCodexPoll();
+      } catch (e) {
+        this.codex.status = 'error';
+        this.codex.error = 'Could not reach the setup server.';
+      }
+    },
+
+    scheduleCodexPoll() {
+      this.stopCodexPolling();
+      if (this.codex.status !== 'waiting' || !this.codex.sessionId) return;
+      this.codex.pollTimer = setTimeout(
+        () => this.pollCodexOauth(),
+        Math.max(2000, this.codex.pollInterval * 1000),
+      );
+    },
+
+    async pollCodexOauth() {
+      const sessionId = this.codex.sessionId;
+      if (!sessionId || this.codex.status !== 'waiting') return;
+      try {
+        const r = await fetch(`/setup/api/oauth/codex/poll/${encodeURIComponent(sessionId)}`);
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) {
+          this.codex.status = 'error';
+          this.codex.error = d.error || 'Authorization status could not be checked.';
+          this.stopCodexPolling();
+          return;
+        }
+        this.codex.status = d.status || 'error';
+        if (d.expires_at) this.codex.expiresAt = d.expires_at;
+        if (this.codex.status === 'waiting') {
+          this.scheduleCodexPoll();
+        } else {
+          this.stopCodexPolling();
+          this.codex.error = d.error || '';
+          if (this.codex.status === 'connected') {
+            this.codex.sessionId = '';
+            await this.loadCodexModels();
+          }
+        }
+      } catch (e) {
+        // A transient browser/network miss should not cancel the native Hermes
+        // session. Keep polling until Hermes reports a terminal state.
+        this.scheduleCodexPoll();
+      }
+    },
+
+    async cancelCodexOauth(showResult = true) {
+      const sessionId = this.codex.sessionId;
+      this.stopCodexPolling();
+      this.codex.sessionId = '';
+      if (sessionId) {
+        try {
+          await fetch(`/setup/api/oauth/codex/sessions/${encodeURIComponent(sessionId)}`, { method: 'DELETE' });
+        } catch {}
+      }
+      this.codex.status = 'canceled';
+      this.codex.error = 'Authorization was canceled.';
+      if (showResult) this.notify('OpenAI Codex authorization canceled', true);
+    },
+
+    async disconnectCodex(ask = true) {
+      if (ask && !confirm('Disconnect OpenAI Codex from this deployment? The gateway will stop if it is using this account.')) return;
+      if (this.codex.sessionId) await this.cancelCodexOauth(false);
+      this.codex.status = 'disconnecting';
+      this.codex.error = '';
+      try {
+        const r = await fetch('/setup/api/oauth/codex', { method: 'DELETE' });
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) {
+          this.codex.status = 'error';
+          this.codex.error = d.error || 'Could not disconnect OpenAI Codex.';
+          return;
+        }
+        this.codex.status = 'not_connected';
+        this.codex.models = [];
+        this.vars._MODEL_OPENAI_CODEX = '';
+        if (ask) this.notify('OpenAI Codex disconnected', true);
+        await this.loadStatus();
+      } catch (e) {
+        this.codex.status = 'error';
+        this.codex.error = 'Could not reach the setup server.';
+      }
+    },
+
+    async loadCodexModels() {
+      this.codex.modelsLoading = true;
+      this.codex.modelsError = '';
+      try {
+        const r = await fetch('/setup/api/oauth/codex/models');
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) {
+          this.codex.models = [];
+          this.codex.modelsError = d.error || 'No compatible Codex models are available.';
+          return;
+        }
+        this.codex.models = d.models || [];
+        const stored = this.vars._MODEL_OPENAI_CODEX || this.vars.LLM_MODEL || '';
+        if (stored && this.codex.models.includes(stored)) {
+          this.vars.LLM_MODEL = stored;
+        } else if (this.codex.models.length === 1) {
+          this.vars.LLM_MODEL = this.codex.models[0];
+          this.vars._MODEL_OPENAI_CODEX = this.codex.models[0];
+        }
+      } catch (e) {
+        this.codex.modelsError = 'Could not load Codex models.';
+      } finally {
+        this.codex.modelsLoading = false;
+      }
+    },
+
+    async copyCodexCode() {
+      try {
+        await navigator.clipboard.writeText(this.codex.userCode || '');
+        this.notify('Authorization code copied', true);
+      } catch {
+        this.notify('Could not copy the code; select it manually', false);
+      }
+    },
+
+    formatCodexExpiry() {
+      if (!this.codex.expiresAt) return '';
+      return new Date(this.codex.expiresAt * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    },
+
     async startXaiOauth() {
       this.xai.loading = true;
       this.xai.error = '';
@@ -2180,6 +2450,13 @@ function app() {
       // setup form — and on the Backup page that looks like the restore blew up.
       ['dragover','drop'].forEach(evt =>
         window.addEventListener(evt, e => { e.preventDefault(); }, false));
+      window.addEventListener('pagehide', () => {
+        if (this.codex.status === 'waiting' && this.codex.sessionId) {
+          fetch(`/setup/api/oauth/codex/sessions/${encodeURIComponent(this.codex.sessionId)}`, {
+            method: 'DELETE', keepalive: true,
+          }).catch(() => {});
+        }
+      });
       await Promise.all([this.loadConfig(), this.loadStatus(), this.loadLogs(), this.loadPairing(), this.loadSnapshots()]);
       setInterval(() => this.loadStatus(),  5000);
       setInterval(() => this.loadLogs(),    3000);
@@ -2192,9 +2469,14 @@ function app() {
         if (r.ok) {
           const d = await r.json();
           this.vars = d.vars || {};
+          if (d.model_config?.provider === 'openai-codex' && d.model_config?.model) {
+            this.vars._MODEL_OPENAI_CODEX = d.model_config.model;
+            if (!this.vars.LLM_MODEL) this.vars.LLM_MODEL = d.model_config.model;
+          }
           // Refresh xAI OAuth status (drives configuredProviders computed getter).
           const xs = await fetch('/setup/api/oauth/xai/status').then(r2 => r2.json()).catch(() => ({ status: 'none' }));
           this.xai.status = xs.status;
+          await this.loadCodexStatus();
           // Detect active channels
           this.channelsEnabled = {
             telegram:   !!(this.vars.TELEGRAM_BOT_TOKEN),
@@ -2209,8 +2491,9 @@ function app() {
           for (const t of this.tools) {
             this.toolsEnabled[t.key] = !!(this.vars[t.key]);
           }
-          // savedConfigComplete: server has at least one provider + model.
-          this.savedConfigComplete = !!(this.vars.LLM_MODEL && this.configuredProviders.length > 0);
+          // The server checks config.yaml plus provider-specific credentials;
+          // do not infer OAuth readiness from .env fields in the browser.
+          this.savedConfigComplete = !!d.config_complete;
         }
       } catch {}
     },
@@ -2219,6 +2502,18 @@ function app() {
       this.saving = true;
       // Sync per-provider model key so the configured list shows the right model.
       const p = this.selectedProvider ? this.providerMap[this.selectedProvider] : null;
+      if (p?.isOauth === 'codex') {
+        if (this.codex.status !== 'connected') {
+          this.notify('Complete OpenAI Codex authorization before saving', false);
+          this.saving = false;
+          return;
+        }
+        if (!this.vars.LLM_MODEL || !this.codex.models.includes(this.vars.LLM_MODEL)) {
+          this.notify('Select an available Codex model before saving', false);
+          this.saving = false;
+          return;
+        }
+      }
       if (p && this.vars.LLM_MODEL) {
         if (p.modelKey) this.vars[p.modelKey] = this.vars.LLM_MODEL;
       }
@@ -2236,6 +2531,7 @@ function app() {
             // soon as a second provider key exists. Empty when the user
             // saved without touching a provider (e.g. just a channel toggle).
             _active_provider_key: (p && p.key) ? p.key : '',
+            _active_oauth_provider: p?.isOauth === 'codex' ? 'openai-codex' : '',
           }),
         });
         if (r.ok) {

--- a/tests/test_codex_oauth.py
+++ b/tests/test_codex_oauth.py
@@ -1,0 +1,318 @@
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+
+os.environ.setdefault("ADMIN_PASSWORD", "test-password")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+import server  # noqa: E402
+
+
+class DummyRequest:
+    def __init__(self, *, path_params=None, body=None):
+        self.path_params = path_params or {}
+        self._body = body or {}
+
+    async def json(self):
+        return dict(self._body)
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def response_payload(response):
+    return json.loads(response.body.decode("utf-8"))
+
+
+class HermesConfigTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.home = Path(self.tempdir.name) / ".hermes"
+        self.home.mkdir(parents=True)
+        self.patch_home = patch.object(server, "HERMES_HOME", str(self.home))
+        self.patch_env = patch.object(server, "ENV_FILE", self.home / ".env")
+        self.patch_official = patch.object(
+            server, "_codex_status_from_hermes", return_value=None
+        )
+        self.patch_home.start()
+        self.patch_env.start()
+        self.patch_official.start()
+
+    def tearDown(self):
+        self.patch_official.stop()
+        self.patch_env.stop()
+        self.patch_home.stop()
+        self.tempdir.cleanup()
+
+    def write_config(self, model="", provider=""):
+        import yaml
+
+        (self.home / "config.yaml").write_text(
+            yaml.safe_dump({"model": {"default": model, "provider": provider}})
+        )
+
+    def write_auth(self, payload):
+        (self.home / "auth.json").write_text(json.dumps(payload))
+
+    def current_codex_auth(self):
+        return {
+            "credential_pool": {
+                "openai-codex": [{
+                    "source": "device_code",
+                    "auth_type": "oauth",
+                    "access_token": "access-current",
+                    "refresh_token": "refresh-current",
+                }]
+            }
+        }
+
+    def test_write_config_preserves_default_without_llm_model(self):
+        self.write_config("gpt-5.3-codex", "openai-codex")
+        server.write_config_yaml({})
+        model, provider, parsed = server._configured_model_from_yaml()
+        self.assertTrue(parsed)
+        self.assertEqual(model, "gpt-5.3-codex")
+        self.assertEqual(provider, "openai-codex")
+
+    def test_write_config_preserves_provider_without_explicit_change(self):
+        self.write_config("gpt-5.3-codex", "openai-codex")
+        server.write_config_yaml({"LLM_MODEL": "gpt-5.2-codex"})
+        model, provider, _ = server._configured_model_from_yaml()
+        self.assertEqual(model, "gpt-5.2-codex")
+        self.assertEqual(provider, "openai-codex")
+
+    def test_explicit_llm_model_updates_default(self):
+        self.write_config("old-model", "openrouter")
+        server.write_config_yaml({"LLM_MODEL": "new-model"})
+        model, provider, _ = server._configured_model_from_yaml()
+        self.assertEqual(model, "new-model")
+        self.assertEqual(provider, "openrouter")
+
+    def test_malformed_config_is_not_overwritten(self):
+        path = self.home / "config.yaml"
+        original = "model: [unterminated\n"
+        path.write_text(original)
+        with self.assertRaises(ValueError):
+            server.write_config_yaml({"LLM_MODEL": "replacement"})
+        self.assertEqual(path.read_text(), original)
+        self.assertFalse(server.is_config_complete({}))
+
+    def test_codex_current_credential_pool_is_complete(self):
+        self.write_config("gpt-5.3-codex", "openai-codex")
+        self.write_auth(self.current_codex_auth())
+        self.assertTrue(server.is_config_complete({}))
+
+    def test_legacy_codex_provider_tokens_are_complete(self):
+        self.write_config("gpt-5.2-codex", "openai-codex")
+        self.write_auth({
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "legacy-access",
+                        "refresh_token": "legacy-refresh",
+                    }
+                }
+            }
+        })
+        self.assertTrue(server.is_config_complete({}))
+
+    def test_codex_provider_without_credentials_is_incomplete(self):
+        self.write_config("gpt-5.3-codex", "openai-codex")
+        self.assertFalse(server.is_config_complete({}))
+
+    def test_codex_credentials_without_model_are_incomplete(self):
+        self.write_config("", "openai-codex")
+        self.write_auth(self.current_codex_auth())
+        self.assertFalse(server.is_config_complete({}))
+
+    def test_dead_codex_pool_entry_is_incomplete(self):
+        auth = self.current_codex_auth()
+        auth["credential_pool"]["openai-codex"][0]["last_status"] = "dead"
+        self.write_config("gpt-5.3-codex", "openai-codex")
+        self.write_auth(auth)
+        self.assertFalse(server.is_config_complete({}))
+
+    def test_existing_api_key_configuration_is_complete(self):
+        self.assertTrue(server.is_config_complete({
+            "LLM_MODEL": "openai/gpt-4o-mini",
+            "OPENROUTER_API_KEY": "not-a-real-key",
+        }))
+
+    def test_existing_xai_oauth_configuration_is_complete(self):
+        self.write_config("grok-4.3", "xai-oauth")
+        self.write_auth({
+            "providers": {
+                "xai-oauth": {"tokens": {"refresh_token": "xai-refresh"}}
+            }
+        })
+        self.assertTrue(server.is_config_complete({}))
+
+    def test_codex_save_uses_hermes_model_api_and_pins_provider(self):
+        import yaml
+
+        self.write_auth(self.current_codex_auth())
+
+        async def apply_model(provider, model, **kwargs):
+            self.write_config(model, provider)
+            return None
+
+        request = DummyRequest(body={
+            "vars": {"LLM_MODEL": "gpt-5.3-codex"},
+            "_active_oauth_provider": "openai-codex",
+            "_restart": False,
+        })
+        model_api = AsyncMock(side_effect=apply_model)
+        with (
+            patch.object(server, "guard", return_value=None),
+            patch.object(server, "set_active_model_via_hermes", model_api),
+        ):
+            response = asyncio.run(server.api_config_put(request))
+
+        self.assertEqual(response.status_code, 200)
+        model_api.assert_awaited_once_with("openai-codex", "gpt-5.3-codex")
+        config = yaml.safe_load((self.home / "config.yaml").read_text())
+        self.assertEqual(config["model"]["provider"], "openai-codex")
+        self.assertEqual(config["model"]["default"], "gpt-5.3-codex")
+        self.assertNotIn("access-current", (self.home / ".env").read_text())
+
+
+class HermesOAuthProxyTest(unittest.TestCase):
+    def test_proxy_attaches_server_side_session_token(self):
+        class FakeClient:
+            def __init__(self):
+                self.call = None
+
+            async def request(self, method, url, **kwargs):
+                self.call = (method, url, kwargs)
+                return FakeResponse(payload={"ok": True})
+
+        client = FakeClient()
+        with (
+            patch.object(server, "_get_hermes_session_token", AsyncMock(return_value="hermes-session-secret")),
+            patch.object(server, "get_http_client", return_value=client),
+        ):
+            result = asyncio.run(server._hermes_api_json(
+                "POST", "/api/providers/oauth/openai-codex/start", json_body={}
+            ))
+        self.assertEqual(result, {"ok": True})
+        self.assertEqual(
+            client.call[2]["headers"],
+            {server._SESSION_TOKEN_HEADER: "hermes-session-secret"},
+        )
+
+    def test_start_poll_cancel_disconnect_are_sanitized(self):
+        secret = "oauth-access-token-that-must-not-leak"
+        session_id = "session_12345678"
+
+        async def fake_call(method, path, **kwargs):
+            if path.endswith("/start"):
+                return {
+                    "session_id": session_id,
+                    "user_code": "ABCD-EFGH",
+                    "verification_url": "https://auth.openai.com/codex/device",
+                    "expires_in": 900,
+                    "poll_interval": 5,
+                    "access_token": secret,
+                }
+            if "/poll/" in path:
+                return {
+                    "status": "denied",
+                    "expires_at": 12345,
+                    "error_message": f"denied with {secret}",
+                }
+            if "/sessions/" in path:
+                return {"ok": True, "refresh_token": secret}
+            return {"ok": True, "access_token": secret}
+
+        with (
+            patch.object(server, "guard", return_value=None),
+            patch.object(server, "_hermes_api_json", AsyncMock(side_effect=fake_call)),
+            patch.object(server, "_configured_model_from_yaml", return_value=("", "", True)),
+        ):
+            start = asyncio.run(server.api_oauth_codex_start(DummyRequest()))
+            poll = asyncio.run(server.api_oauth_codex_poll(
+                DummyRequest(path_params={"session_id": session_id})
+            ))
+            cancel = asyncio.run(server.api_oauth_codex_cancel(
+                DummyRequest(path_params={"session_id": session_id})
+            ))
+            disconnect = asyncio.run(server.api_oauth_codex_disconnect(DummyRequest()))
+
+        combined = b"".join(r.body for r in (start, poll, cancel, disconnect)).decode()
+        self.assertNotIn(secret, combined)
+        self.assertEqual(response_payload(start)["status"], "waiting")
+        self.assertEqual(response_payload(poll)["status"], "denied")
+        self.assertEqual(response_payload(cancel)["status"], "canceled")
+        self.assertEqual(response_payload(disconnect)["status"], "not_connected")
+
+    def test_provider_status_does_not_expose_tokens_or_session_credentials(self):
+        secret = "provider-secret-token"
+        upstream = {
+            "providers": [{
+                "id": "openai-codex",
+                "status": {
+                    "logged_in": True,
+                    "token_preview": secret,
+                    "api_key": secret,
+                    "session_token": secret,
+                },
+            }]
+        }
+        with (
+            patch.object(server, "guard", return_value=None),
+            patch.object(server, "_hermes_api_json", AsyncMock(return_value=upstream)),
+            patch.object(server, "_configured_model_from_yaml", return_value=("gpt-5.3-codex", "openai-codex", True)),
+        ):
+            response = asyncio.run(server.api_oauth_codex_status(DummyRequest()))
+        rendered = response.body.decode()
+        self.assertNotIn(secret, rendered)
+        self.assertEqual(response_payload(response), {
+            "available": True,
+            "connected": True,
+            "status": "connected",
+            "model": "gpt-5.3-codex",
+        })
+
+    def test_model_list_is_allowlisted_and_filters_unavailable(self):
+        payload = {
+            "providers": [{
+                "slug": "openai-codex",
+                "models": ["gpt-5.3-codex", {"id": "gpt-5.2-codex"}],
+                "unavailable_models": ["gpt-5.2-codex"],
+                "access_token": "must-not-leak",
+            }]
+        }
+        self.assertEqual(server._codex_models_public(payload), ["gpt-5.3-codex"])
+
+    def test_upstream_error_body_is_not_forwarded_or_logged(self):
+        secret = "raw-upstream-refresh-token"
+
+        class RejectingClient:
+            async def request(self, *args, **kwargs):
+                return FakeResponse(400, {"detail": secret}, text=secret)
+
+        with (
+            patch.object(server, "_get_hermes_session_token", AsyncMock(return_value="session")),
+            patch.object(server, "get_http_client", return_value=RejectingClient()),
+        ):
+            with self.assertRaises(server.HermesProxyError) as raised:
+                asyncio.run(server._hermes_api_json("POST", "/api/providers/oauth/openai-codex/start"))
+        self.assertNotIn(secret, raised.exception.message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The Railway setup wizard only considered API-key providers (plus its separate xAI OAuth flow) when deciding whether Hermes was configured. Native Hermes already supports ChatGPT device-code OAuth through the `openai-codex` provider, but the template could not start or preserve a Codex-only configuration.

Closes #34. Supersedes the startup-only approach in #51 with the current pinned Hermes credential-pool layout and a complete `/setup` flow.

## User-visible flow

- Select **OpenAI Codex (ChatGPT subscription)** on `/setup`.
- Start native Hermes device-code authorization.
- Open the verification URL, copy the user code, and see waiting, approved, denied, expired, canceled, or error states.
- After connection, choose a model returned by Hermes and use **Save & Start** without an OpenAI API key.
- Disconnect the account or authorize again from the same page.

## Technical approach

- Reuses the OAuth and token lifecycle built into pinned Hermes `v2026.8.3`; the Railway wrapper does not implement an OAuth client, token exchange, or client secret.
- Adds narrow authenticated wrapper endpoints around Hermes' provider OAuth, polling, cancellation, disconnect, model-options, and model-setting APIs.
- Attaches the Hermes dashboard session token only server-side and projects allowlisted browser responses. Access tokens, refresh tokens, dashboard session tokens, raw auth-store contents, and upstream error bodies are never returned.
- Makes readiness aware of `config.yaml`, explicit `model.provider: openai-codex`, the official Hermes Codex status helper, current `credential_pool.openai-codex`, and the legacy provider-token layout.
- Preserves dashboard-selected model/provider configuration when `.env` has no `LLM_MODEL`, while retaining API-key and xAI OAuth behavior.
- Stops or refuses gateway startup when Codex credentials/configuration are missing or malformed.

## Persistence and security

Hermes remains the sole owner of OAuth credentials under `/data/.hermes/`. A persistent `/data` Railway volume is required to reuse authorization after restart or redeploy. The documentation calls out that service, shell, backup, and volume access must be treated as sensitive infrastructure.

## Verification

- `../hermes-test-venv/bin/python -m unittest discover -s tests -v` — 17 tests passed.
- `python3 -m py_compile server.py` — passed.
- Inline setup JavaScript parsed with `node --check` — passed.
- `git diff --check` — passed.
- Full Docker image build with pinned Hermes `v2026.8.3` — passed.
- Fresh-container smoke: health endpoint OK, unauthenticated root redirected to `/setup`, Codex provider/status endpoint present, and a real native device-code session successfully started and canceled.
- Browser smoke: provider selection, verification link, user code, copy, expiration/status, and cancel UI were exercised locally.

No real OpenAI account was approved during testing. Connected/model/save/restart behavior is covered by mocked Hermes interactions and persisted-config readiness tests, keeping the test independent of user credentials.

## Backward compatibility

- Existing API-key readiness remains covered.
- Existing xAI OAuth readiness remains covered.
- Legacy `providers.openai-codex.tokens` credentials are recognized alongside the pinned version's credential pool.
- Existing unrelated `config.yaml` sections remain deep-merged.

## Prior context

- Issue #34
- Previous unmerged attempt #51
