### PR TITLE
chore: bump HERMES_REF to v2026.8.31 and document main override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 # newest tag (format `vYYYY.M.D`, optionally with a `.PATCH` suffix, e.g.
 # `v2026.5.29.2`) and update the default below. Use `main` only if you accept
 # that every rebuild can pull arbitrary new upstream commits.
-ARG HERMES_REF=v2026.8.27
+ARG HERMES_REF=v2026.8.31
 
 # Persist the build arg into the runtime env so the admin UI can display which
 # Hermes release this image actually pins. Reading it (rather than hardcoding a

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ Open `http://localhost:8080` and log in with `admin` / `changeme`.
 
 ## Updating Hermes
 
-This template pins a specific Hermes Agent release in the `Dockerfile` (`ARG HERMES_REF`, currently `v2026.8.27`). To upgrade:
+This template pins a specific Hermes Agent release in the `Dockerfile` (`ARG HERMES_REF`, currently `v2026.8.31`). To upgrade:
 
-- **Recommended:** set a `HERMES_REF` service variable in Railway to any upstream [release tag](https://github.com/NousResearch/hermes-agent/releases) (e.g. `v2026.8.27`), then redeploy. It's passed in as a Docker build arg and overrides the Dockerfile default — no code change needed.
+- **Recommended:** set a `HERMES_REF` service variable in Railway to any upstream [release tag](https://github.com/NousResearch/hermes-agent/releases) (e.g. `v2026.8.31`) or branch (`main`), then redeploy. It's passed in as a Docker build arg and overrides the Dockerfile default — no code change needed. Use `main` only for unreleased fixes (e.g. the `EMAIL_*_TLS_VERIFY` toggle for self-hosted email bridges) and expect every rebuild to pull new upstream commits.
 - **Or** bump `ARG HERMES_REF` in the `Dockerfile` and redeploy.
 
 The "Update" button inside the Hermes dashboard is a **no-op on Railway** (it detects a container install and refuses) — the image is immutable, so a runtime self-update wouldn't survive a redeploy. Bump `HERMES_REF` and redeploy instead. When jumping releases, re-check that the Dockerfile's install extras still match upstream's `pyproject.toml`.


### PR DESCRIPTION
## What

Bump the default `ARG HERMES_REF` from `v2026.8.27` to `v2026.8.31` (the latest release, v0.21.0), and document the `main` override in the README.

## Why

The template currently pins an older release. More concretely, I hit a real bug on a deployment that this bump helps users avoid: the email platform failed to connect to a self-hosted [Proton Mail Bridge](https://proton.me/mail/bridge) with:

```
SMTP connection failed: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate
```

Root cause: the email adapter (`plugins/platforms/email/adapter.py`) used `ssl.create_default_context()` unconditionally, so a bridge's self-signed certificate is rejected. The upstream fix landed on `main` as commit `92a9864517` (`feat(email): configurable IMAP/SMTP transport security (tls/starttls/plain) and TLS verify toggle`), which adds the opt-in `EMAIL_IMAP_TLS_VERIFY` / `EMAIL_SMTP_TLS_VERIFY` env vars.

That commit landed **2026-09-02**, which is *after* the `v2026.8.31` release, so it is not in any release tag yet. This PR therefore does two things:

1. Bumps the default to the latest release (`v2026.8.31`) as routine maintenance.
2. Documents in the README that operators needing unreleased fixes can set the `HERMES_REF` service variable to `main` (already supported — Railway passes it through as a Docker build arg), so the `EMAIL_*_TLS_VERIFY` fix is reachable today without forking the template.

No other changes.
