### PR TITLE
Upgrade Hermes Agent to v2026.8.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,144 @@ release.
 
 ---
 
+## release/v2026.8.31/1 — September 6, 2026
+**Hermes v2026.8.31 · major (Hermes upgrade, from v2026.8.27)**
+
+### Hermes update
+- Hermes Agent **v2026.8.27 → v2026.8.31** (package 0.20.6 → 0.21.0). Three new
+  providers (Tencent TokenPlan, Ramp Router, Nebius Token Factory), Kanban board
+  export/import, and hosted Group Chat rooms (off by default,
+  `gateway.room_link_url` unset).
+- **Anthropic subscription OAuth was REMOVED from the dashboard.** Upstream
+  deleted `_start_anthropic_pkce`/`_submit_anthropic_pkce` and flipped the
+  catalog entry to `flow: "external"` — an unattended HTTP endpoint minting
+  Claude Pro/Max tokens sat on the wrong side of Anthropic's OAuth policy.
+  `POST /api/providers/oauth/anthropic/start` now 400s. The terminal path
+  (`hermes auth add anthropic`, runnable from the Chat tab) is unaffected.
+- **`agent.gateway_turn_lease_timeout` 1800 → 5.** A second message on a session
+  whose turn is still running is now rejected with a resend notice after ~5s
+  instead of blocking for up to 30 minutes. Still config.yaml-only —
+  `gateway/run.py` writes `HERMES_TURN_LEASE_TIMEOUT` into `os.environ`
+  unconditionally at import, so a Railway variable is clobbered.
+- **Scanned PDFs can now be OCR'd** when a `FIRECRAWL_API_KEY` is present:
+  firecrawl-anydoc 0.2.4 adds a typed `NeedsOcrError` and a hosted OCR path
+  (`tools/read_extract.py`). Opt out with `file_tools.hosted_ocr: false`.
+
+### Changes to support upstream updates
+- **PDF and Office reading would have broken on every deploy.** v2026.8.31 moved
+  `firecrawl-anydoc` out of lazy-install and into CORE `dependencies` at
+  `==0.2.4`, and bumped the lazy self-heal pin in `tools/lazy_deps.py` to match.
+  This template carried a later Dockerfile layer pinning `==0.1.6` (correct when
+  the package was lazy-only), which **downgrades** the core version at build
+  time. `_is_satisfied()` compares versions rather than presence, so the first
+  `.pdf/.docx/.xlsx/.pptx/.odt/.rtf/.epub` read tried to heal into
+  `HERMES_LAZY_INSTALL_TARGET` with a `--constraint` file generated from every
+  installed distribution — which pins `firecrawl-anydoc==0.1.6` — and uv
+  hard-failed `No solution found`. Reproduced locally with uv: the downgrade,
+  the resolver conflict, and `hasattr(anydoc, "NeedsOcrError") == False`. Every
+  document read would have failed, on every deploy, retried every 300s
+  (`ANYDOC_RETRY_SECONDS`) and never succeeding. The layer is deleted; core now
+  supplies 0.2.4.
+- **Tavily is gone from Hermes, so it is gone from Setup.** Upstream deleted
+  `plugins/web/tavily/` and every `TAVILY_API_KEY` reader with it (11 modules →
+  1 stale comment in `agent/redact.py`); `hermes_cli/setup.py` now advertises
+  "Exa, Parallel, Firecrawl, or Keenable". `ENV_VARS` and the setup UI offered a
+  field whose value nothing reads. Worse for anyone who had explicitly stored
+  `web.backend: tavily` from hermes' own Tools tab: `_get_backend()`
+  (`tools/web_tools.py`) returns a stored selection **strictly**, with no
+  availability probe and no fallback, so `web_search` returns
+  `no registered web search provider has that name` on every call. Replaced
+  with `KEENABLE_API_KEY`. An existing `TAVILY_API_KEY` on the volume is left
+  alone (config saves preserve keys outside `ENV_VARS`) — it is simply inert.
+- **Restarts no longer risk a torn `state.db`.** `Gateway.stop()` waited 45s
+  before SIGKILL. The v2026.8.31 stop path is a chain — `cron_drain_timeout`
+  (30) + `CRON_DRAIN_CLEANUP_RESERVE_S` (10) + the new
+  `gateway.signal_interrupt_grace_timeout` + adapter teardown + a newly bounded
+  MCP shutdown + a PASSIVE WAL checkpoint in `SessionDB.close()` — which with an
+  in-flight cron job runs ~56s. Upstream sizes its own supervisors at
+  `max(60, max(drain, cron+10) + 30)` = 70s
+  (`gateway/restart.py: resolve_systemd_timeout_stop_sec`) and raised its
+  orphan-reaper grace 5s → 30s after a SIGKILL during that checkpoint corrupted
+  `state.db` (the 2026-08-31 incident named in `hermes_cli/gateway.py`, which
+  also added a boot-time `PRAGMA quick_check`). Raised to 70s, which sits
+  *behind* hermes' own 60s shutdown watchdog — the watchdog hard-exits and
+  releases the pid file and lock itself, so this SIGKILL should now never fire.
+- **Terminal scratch stays off the volume.** v2026.8.31 changed the default
+  temp root in `tools/environments/local.py` from `/tmp` to
+  `$HERMES_HOME/cache/terminal` whenever `TERMINAL_TEMP_DIR` and `TMPDIR` are
+  both unset (upstream's motive was a tmpfs `/tmp` filling up). Here
+  `$HERMES_HOME` is the persistent volume: sandbox dirs and background-job logs
+  would accumulate on `/data`, ship inside every `hermes backup` (`cache/` is
+  not in upstream's `_EXCLUDED_DIRS`), and a locked `*.db` left there by an
+  agent script would fail `_safe_copy_db` — which `_live_db_names()` reports as
+  an incomplete snapshot and which **aborts a restore**. `build_hermes_env()`
+  now sets `TERMINAL_TEMP_DIR=/tmp`, restoring the v2026.8.27 behaviour.
+
+### Bug fixes
+- **A profile switch can no longer hijack the gateway.** `hermes_cli/main.py`'s
+  `_apply_profile_override()` runs at *import*, before argparse, and follows
+  `$HERMES_HOME/active_profile` — written by hermes' own dashboard and by
+  `hermes profile use` in the Chat terminal. Our `--external-supervisor` flag
+  only sets `HERMES_GATEWAY_EXTERNAL_SUPERVISOR` *after* parsing, so it was
+  always too late. One switch silently re-homed the gateway, the dashboard and
+  the dashboard's detached restart under `profiles/<name>`: pairing, config and
+  the pid record then diverged from what the admin panel reads, and the next
+  `--replace` refused with "pid record belongs to a different HERMES_HOME".
+  v2026.8.31 added `HERMES_SUPERVISED_CHILD` (#74872) as the opt-out and
+  `build_hermes_env()` now sets it. It is read *only* by that guard, never by
+  `is_gateway_supervisor_process()` or the s6 redirect, so the exit-75 contract
+  is untouched. (Hazard predates this release; the opt-out is new.)
+- **Dashboard credentials in `.env` can no longer lock every page out.** hermes
+  loads `$HERMES_HOME/.env` into its own `os.environ` with `override=True` at
+  startup — i.e. *after* the env `build_hermes_env()` hands the subprocess — so
+  a `HERMES_DASHBOARD_BASIC_AUTH_*` value in the FILE beats the credentials we
+  pass. hermes' `basic` provider then registers a different pair than
+  `HermesSession` signs in with and every proxied page 502s with no explanation.
+  A restore, a hand edit, or hermes' own Keys tab can all put them there. The
+  four keys join `ENV_FILE_FORBIDDEN_KEYS` (file only — they remain honoured as
+  genuine Railway variables, which `hermes_dashboard_credentials()` reads from
+  the same `os.environ`). Same class as the existing `HERMES_PARENT_PID` strip.
+- **A fatal config error no longer crash-loops.** Exit 78
+  (`GATEWAY_FATAL_CONFIG_EXIT_CODE`) means an invalid multiplexer config or every
+  enabled platform failing non-retryably — upstream pairs `Restart=always` with
+  `RestartPreventExitStatus=78` for exactly this, and deliberately avoids 78 when
+  the failure is mixed/transient. The supervisor now reports it and stops instead
+  of burning the crash-loop budget on the same error. Unexpected-exit lines are
+  also `print()`ed now, so they reach `railway logs` and not only the Logs panel.
+
+### Housekeeping
+- `requirements.txt` floor `uvicorn>=0.30` → `>=0.31`, tracking hermes' own core
+  pin (CIDR-aware `forwarded_allow_ips`). Same system site-packages either way.
+
+### Verified unchanged (audited, no action)
+Two independent passes covered all 1,657 changed upstream files. Still identical:
+the WebSocket route set (`pty`/`ws`/`events`/`console`/`pub`/kanban) and the
+SPA's socket usage, so the fail-closed allowlist is complete; `ws_max_size`
+(384 MiB) and the loopback ping settings on both hops; `host_header_middleware`
+and the whole middleware stack, so Host-stripping still satisfies it;
+`should_require_auth` / `should_require_dashboard_auth` / `_dashboard_public_hosts`
+/ `resolve_public_url` and the `basic` provider, so the auth-gate pairing and
+`/auth/password-login` are unchanged (the new `_desktop_loopback_auth_exempt`
+needs `HERMES_DESKTOP=1` plus a session token, neither of which is ever set
+here); `detect_install_method` and `is_container` (both container markers), so
+the docker stamp still refuses the Update button; the exit-75 restart contract
+and all six `--replace` refusal branches; `gateway/pairing.py` and the
+`get_hermes_dir("platforms/pairing", "pairing")` rule byte-for-byte; every
+backup constant (`_EXCLUDED_DIRS`, `_IMPORT_SKIP_NAMES`, the validator markers,
+`backup -o`, `import --force`); `state.db` `SCHEMA_VERSION` 26, so a v2026.8.27
+archive restores onto v2026.8.31 unmigrated; all nine install extras; the web
+build `outDir` and the `HERMES_TUI_DIR` contract.
+
+Two earlier notes in this repo were **wrong** and are corrected: the dashboard
+*lifespan* orphan reaper is gated on `HERMES_DESKTOP=1` and never runs here
+(only `_spawn_gateway_restart` reaps, and its exemption set is built from the
+raw `gateway.pid` + `gateway.lock` records plus an unbounded parent walk, not
+"up to 4 hops"); and `lightpanda` was added to `_POST_SETUP_READY`, an
+interactive-CLI prompt gate, **not** to `_POST_SETUP_INSTALLED`, which still
+holds only `cua_driver` — so the install-on-enable HTTP path is unchanged.
+
+---
+
 ## release/v2026.8.27/1 — August 29, 2026
 **Hermes v2026.8.27 · major (Hermes upgrade, from v2026.8.13)**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 # newest tag (format `vYYYY.M.D`, optionally with a `.PATCH` suffix, e.g.
 # `v2026.5.29.2`) and update the default below. Use `main` only if you accept
 # that every rebuild can pull arbitrary new upstream commits.
-ARG HERMES_REF=v2026.8.27
+ARG HERMES_REF=v2026.8.31
 
 # Persist the build arg into the runtime env so the admin UI can display which
 # Hermes release this image actually pins. Reading it (rather than hardcoding a
@@ -44,10 +44,10 @@ RUN apt-get update && \
 # [all] in v2026.6.5 no longer pulls in [dev]; messaging platforms, TTS, and
 # other heavy backends are lazy-installed by hermes at first use. We pre-install
 # the ones this template actually uses so first-message latency is instant.
-# `vision` (Pillow) is a soft-dep that is NOT in [all] and is otherwise
-# lazy-installed at first image use: without it hermes can't downscale an
-# oversized image (>5 MB / >8000px), which then bakes into immutable history
-# and bricks the session on Anthropic's non-retryable 400. We bake it in.
+# `vision` guards image downscaling (without Pillow an oversized image >5 MB /
+# >8000px bakes into immutable history and bricks the session on Anthropic's
+# non-retryable 400). The extra itself has been EMPTY since v2026.6.19 — Pillow
+# moved into core deps — so it resolves to a no-op; kept for back-compat.
 # When bumping HERMES_REF, re-check hermes-agent's pyproject.toml [all] and
 # the extras below against the new release's pyproject.toml.
 #
@@ -105,21 +105,22 @@ RUN git clone --depth 1 --branch ${HERMES_REF} https://github.com/NousResearch/h
 # editable from /opt/hermes-agent.
 RUN printf 'docker\n' > /opt/hermes-agent/.install_method
 
-# firecrawl-anydoc: hermes v2026.8.13's PDF / legacy-Office reader for read_file.
-# It is a LAZY dep (tools/lazy_deps.py "tool.doc_extract"), NOT an extra — so it
-# cannot be added to the `.[...]` string above; upstream deliberately withheld a
-# `doc-extract` extra until the package clears uv's 14-day exclude-newer window
-# (first release 2026-08-04). Without it baked in, the FIRST time the agent reads
-# a .pdf/.docx/.xlsx/.pptx/.odt/.rtf/.epub it pip-installs mid-turn into the
-# running container — which this image wipes on every redeploy, so it re-installs
-# after each deploy, and a failed install is retried only every 300s
-# (ANYDOC_RETRY_SECONDS) while the file silently reads as binary garbage.
+# firecrawl-anydoc (the PDF / legacy-Office reader behind read_file) is a CORE
+# dependency as of v2026.8.31 — pyproject.toml pins ==0.2.4 and exempts it from
+# [tool.uv] exclude-newer, so the main install above already has it.
 #
-# `cd /` is LOAD-BEARING: run from /opt/hermes-agent, uv reads that pyproject's
-# [tool.uv] exclude-newer="14 days" and REJECTS this package as too new. From /
-# there is no pyproject to discover, so the pin resolves normally (~2s, 3 MiB,
-# no transitive deps). Drop this layer once upstream ships the mirrored extra.
-RUN cd / && uv pip install --system --no-cache firecrawl-anydoc==0.1.6
+# Do NOT re-pin it in a later layer. We used to (==0.1.6, when it was lazy-only):
+# that layer runs AFTER the editable install and uv DOWNGRADES the core version,
+# and v2026.8.31 also bumped the lazy self-heal pin (tools/lazy_deps.py
+# "tool.doc_extract") to ==0.2.4. _is_satisfied() compares versions, not
+# presence, so the first PDF read tries to heal into HERMES_LAZY_INSTALL_TARGET
+# with a --constraint file built from every installed dist — which pins
+# firecrawl-anydoc==0.1.6 — and uv hard-fails "No solution found". Result:
+# EVERY PDF/.docx/.xlsx/.pptx/.odt/.rtf/.epub read fails, on every deploy,
+# retried every 300s (ANYDOC_RETRY_SECONDS) and never succeeding.
+#
+# Same trap for any other package we might pin separately: on a version bump,
+# grep the new pyproject's core dependencies for anything this Dockerfile pins.
 
 COPY requirements.txt /app/requirements.txt
 RUN uv pip install --system --no-cache -r /app/requirements.txt

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Telegram, Discord, Slack, WhatsApp, Email, Mattermost, Matrix
 
 ## Supported Tool Integrations
 
-Parallel (search), Firecrawl (scraping), Tavily (search), FAL (image gen), Browserbase, GitHub, OpenAI Voice (Whisper/TTS), Honcho (memory)
+Parallel (search), Firecrawl (scraping), Keenable (search), FAL (image gen), Browserbase, GitHub, OpenAI Voice (Whisper/TTS), Honcho (memory)
 
 ## Architecture
 
@@ -120,9 +120,9 @@ Open `http://localhost:8080` and log in with `admin` / `changeme`.
 
 ## Updating Hermes
 
-This template pins a specific Hermes Agent release in the `Dockerfile` (`ARG HERMES_REF`, currently `v2026.8.27`). To upgrade:
+This template pins a specific Hermes Agent release in the `Dockerfile` (`ARG HERMES_REF`, currently `v2026.8.31`). To upgrade:
 
-- **Recommended:** set a `HERMES_REF` service variable in Railway to any upstream [release tag](https://github.com/NousResearch/hermes-agent/releases) (e.g. `v2026.8.27`), then redeploy. It's passed in as a Docker build arg and overrides the Dockerfile default — no code change needed.
+- **Recommended:** set a `HERMES_REF` service variable in Railway to any upstream [release tag](https://github.com/NousResearch/hermes-agent/releases) (e.g. `v2026.8.31`), then redeploy. It's passed in as a Docker build arg and overrides the Dockerfile default — no code change needed.
 - **Or** bump `ARG HERMES_REF` in the `Dockerfile` and redeploy.
 
 The "Update" button inside the Hermes dashboard is a **no-op on Railway** (it detects a container install and refuses) — the image is immutable, so a runtime self-update wouldn't survive a redeploy. Bump `HERMES_REF` and redeploy instead. When jumping releases, re-check that the Dockerfile's install extras still match upstream's `pyproject.toml`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 starlette>=0.40.0
-uvicorn>=0.30.0
+# Floor tracks hermes' own core pin (>=0.31.0 since v2026.8.31, for CIDR-aware
+# forwarded_allow_ips) — same system site-packages, so keep them consistent.
+uvicorn>=0.31.0
 jinja2>=3.1.0
 python-multipart>=0.0.9
 httpx>=0.27.0

--- a/server.py
+++ b/server.py
@@ -294,7 +294,10 @@ ENV_VARS = [
     ("CUSTOM_PROVIDER_NAME",     "Custom Provider name",     "custom",    False),
     ("PARALLEL_API_KEY",         "Parallel (search)",        "tool",      True),
     ("FIRECRAWL_API_KEY",        "Firecrawl (scrape)",       "tool",      True),
-    ("TAVILY_API_KEY",           "Tavily (search)",          "tool",      True),
+    # Keenable replaced Tavily in v2026.8.31 — upstream DELETED plugins/web/tavily
+    # and every TAVILY_API_KEY reader with it, so the old field wrote a key
+    # nothing reads. Keenable is the vendor hermes' own setup now offers instead.
+    ("KEENABLE_API_KEY",         "Keenable (search)",        "tool",      True),
     ("FAL_KEY",                  "FAL (image gen)",          "tool",      True),
     ("BROWSERBASE_API_KEY",      "Browserbase key",          "tool",      True),
     ("BROWSERBASE_PROJECT_ID",   "Browserbase project",      "tool",      False),
@@ -700,9 +703,26 @@ def hermes_dashboard_public_url() -> str:
 # (reproduced locally for HERMES_PARENT_PID against v2026.8.13).
 DASHBOARD_KILLING_KEYS = ("HERMES_PARENT_PID", "HERMES_DASHBOARD_PUBLIC_URL")
 
+# Keys that don't kill the dashboard but change WHO it trusts. hermes loads
+# $HERMES_HOME/.env into its own os.environ with override=True at startup —
+# i.e. AFTER the env build_hermes_env() hands the subprocess — so a value in the
+# FILE beats the credentials we pass. hermes' `basic` provider then registers a
+# different user/password than HermesSession signs in with, every proxied page
+# 502s with DASHBOARD_AUTH_FAILED_HTML, and nothing says why. A restore, a hand
+# edit, or hermes' own Keys tab can all put them there.
+#
+# Only the FILE is policed: hermes_dashboard_credentials() deliberately honours
+# these as explicit overrides when they arrive as real Railway variables.
+DASHBOARD_TRUST_KEYS = (
+    "HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
+    "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD",
+    "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH",
+    "HERMES_DASHBOARD_BASIC_AUTH_SECRET",
+)
+
 # Only a restored or hand-edited .env can carry these, so .env is healed once at
 # boot and after a restore rather than checked on every read.
-ENV_FILE_FORBIDDEN_KEYS = DASHBOARD_KILLING_KEYS
+ENV_FILE_FORBIDDEN_KEYS = DASHBOARD_KILLING_KEYS + DASHBOARD_TRUST_KEYS
 
 
 def build_hermes_env() -> dict[str, str]:
@@ -738,6 +758,32 @@ def build_hermes_env() -> dict[str, str]:
     # config.yaml, and inherited by all three restart paths (in-band, SIGUSR1,
     # and the dashboard's detached restart). setdefault: set e.g. 120 to re-arm.
     env.setdefault("HERMES_RESTART_AFTER_TURN_TIMEOUT", "0")
+    # v2026.8.31 moved the terminal/code-exec scratch root from /tmp to
+    # $HERMES_HOME/cache/terminal whenever TERMINAL_TEMP_DIR and TMPDIR are both
+    # unset (tools/environments/local.py). Upstream's motive was a tmpfs /tmp
+    # filling up; on Railway /tmp is ordinary container disk and $HERMES_HOME is
+    # the PERSISTENT VOLUME, so the new default parks sandbox dirs and
+    # background-job logs on /data, ships them inside every `hermes backup`
+    # (cache/ is not in upstream's _EXCLUDED_DIRS), and lets a locked *.db an
+    # agent script leaves there fail _safe_copy_db — which _live_db_names() then
+    # reports as an incomplete snapshot and ABORTS the restore. Pin the
+    # v2026.8.27 behaviour. Must be an existing absolute dir or hermes ignores it
+    # (/tmp always exists here).
+    env.setdefault("TERMINAL_TEMP_DIR", "/tmp")
+    # Pin every hermes subprocess to the root profile. hermes_cli/main.py's
+    # _apply_profile_override() runs at IMPORT — before argparse — so the
+    # `--external-supervisor` flag we pass (which only sets
+    # HERMES_GATEWAY_EXTERNAL_SUPERVISOR after parsing) is too late to stop it.
+    # It follows $HERMES_HOME/active_profile, which hermes' own dashboard and a
+    # `hermes profile use` in the Chat terminal both write. One such switch would
+    # silently re-home the gateway, the dashboard AND the dashboard's detached
+    # restart under profiles/<name>: pairing, config and the pid record then
+    # diverge from what this admin panel reads, and the next `--replace` refuses
+    # with "pid record belongs to a different HERMES_HOME". v2026.8.31 added this
+    # generic marker (#74872) as the opt-out; it is read ONLY by that guard
+    # (main.py `_under_gateway_supervisor`), never by is_gateway_supervisor_process()
+    # or the s6 redirect, so it cannot alter the exit-75 restart contract.
+    env.setdefault("HERMES_SUPERVISED_CHILD", "1")
     # Drop inbound values first: the template is the only thing allowed to
     # decide these (this pop covers a Railway service variable, which lands in
     # our own os.environ; _sanitize_env_file() covers the .env file).
@@ -760,7 +806,7 @@ def build_hermes_env() -> dict[str, str]:
 
 
 def _sanitize_env_file() -> None:
-    """Drop keys from .env that would let hermes kill its own dashboard."""
+    """Drop .env keys that would kill the dashboard or break its sign-in."""
     try:
         data = read_env(ENV_FILE)
     except OSError:
@@ -776,10 +822,24 @@ def _sanitize_env_file() -> None:
         print(f"[server] could not strip {removed} from .env: {e}", flush=True)
         return
     print(f"[server] removed {', '.join(removed)} from .env — it would have "
-          f"shut the dashboard down", flush=True)
+          f"shut the dashboard down or broken its sign-in", flush=True)
 
 
 def write_env(path: Path, data: dict[str, str]) -> None:
+    # Single chokepoint keeping ENV_FILE_FORBIDDEN_KEYS out of the FILE, not just
+    # out of the subprocess env. _sanitize_env_file() only runs at boot and after
+    # a restore, but /setup/api/config re-reads .env, merges it and writes it back
+    # — so a key added to the file between boots (hand edit, hermes' own Keys tab)
+    # survived that round-trip and reached the dashboard restart that same save
+    # triggers. Verified live: with a stray HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+    # the dashboard accepted THAT password and 401'd the template's own, which a
+    # still-valid persisted session hid until the next re-login.
+    forbidden = [k for k in ENV_FILE_FORBIDDEN_KEYS if k in data]
+    if forbidden:
+        data = {k: v for k, v in data.items() if k not in ENV_FILE_FORBIDDEN_KEYS}
+        print(f"[server] refused to write {', '.join(forbidden)} to .env — "
+              f"it would have shut the dashboard down or broken its sign-in",
+              flush=True)
     path.parent.mkdir(parents=True, exist_ok=True)
     cat_order = ["model", "provider", "bedrock", "azure", "custom", "tool",
                  "telegram", "discord", "slack", "whatsapp",
@@ -1366,15 +1426,25 @@ class Gateway:
         self.state = "stopping"
         self.proc.terminate()
         try:
-            # 45s, not 20s: v2026.8.27 added `agent.cron_drain_timeout` (default
-            # 30) so a SIGTERM now waits for an in-flight cron job to finish
-            # before tearing down adapters. At 20s we SIGKILLed mid-drain,
-            # defeating that and leaving the job marked running forever. 45s
-            # clears the 30s drain plus adapter teardown (Telegram + Discord +
-            # Slack polling loops) and still sits inside hermes' own 60s
-            # shutdown watchdog. SIGKILL also skips hermes' atexit pid cleanup,
-            # which is exactly the mess _clear_stale_pidfile() then mops up.
-            await asyncio.wait_for(self.proc.wait(), timeout=45)
+            # 70s, not 45s. The stop path is a chain, not one timeout:
+            # `agent.cron_drain_timeout` (30) waits out an in-flight cron job,
+            # + CRON_DRAIN_CLEANUP_RESERVE_S (10), + the new v2026.8.31
+            # `gateway.signal_interrupt_grace_timeout`, + adapter teardown (~5s
+            # each for Telegram/Discord/Slack) + a bounded MCP shutdown + a
+            # PASSIVE WAL checkpoint in SessionDB.close(). With a cron job in
+            # flight that runs ~56s, so 45s landed our SIGKILL mid-teardown.
+            # v2026.8.31 sizes its OWN supervisors at
+            # max(60, max(drain, cron+10) + 30) = 70s
+            # (gateway/restart.py resolve_systemd_timeout_stop_sec) and raised
+            # its orphan-reaper grace 5s -> 30s after a SIGKILL during that
+            # checkpoint corrupted state.db (the 2026-08-31 incident named in
+            # hermes_cli/gateway.py). Matching 70 puts us BEHIND hermes' own 60s
+            # shutdown watchdog, which hard-exits and releases the pid file and
+            # lock itself — so this SIGKILL should now never fire, and the
+            # pid-file mess _clear_stale_pidfile() mops up stops happening.
+            # On a container stop Railway's own grace period is the real
+            # deadline; this bound only governs Restart / config-save.
+            await asyncio.wait_for(self.proc.wait(), timeout=70)
         except asyncio.TimeoutError:
             self.proc.kill()
             await self.proc.wait()
@@ -1398,10 +1468,28 @@ class Gateway:
         # A deliberate stop()/restart()/reset owns its own lifecycle — don't respawn.
         if self._stopping:
             return
+        # Exit 78 = GATEWAY_FATAL_CONFIG_EXIT_CODE (gateway/restart.py): a
+        # config error that no retry can fix — an invalid multiplexer config, or
+        # every enabled platform failing non-retryably. Upstream's own generated
+        # systemd unit pairs Restart=always with
+        # RestartPreventExitStatus=78 for exactly this, and deliberately does
+        # NOT use 78 when the failure is mixed/transient, so honouring it here
+        # cannot suppress a recoverable restart. Respawning would just burn the
+        # crash-loop budget on the same error and bury the reason.
+        if rc == 78:
+            self.state = "crashed"
+            msg = ("[gateway] exited (code 78: fatal config) — not respawning. "
+                   "Fix the configuration, then Start the gateway.")
+            self.logs.append(msg)
+            print(msg, flush=True)
+            return
         # Unexpected exit: in-band `/restart` (exit 75), a crash, or an OOM kill.
         # On Railway nothing else brings the gateway back, so we supervise it.
         self.state = "error"
+        # print() as well as the ring buffer: an unexpected exit is the one
+        # supervisor event worth having in `railway logs` without opening /setup.
         self.logs.append(f"[gateway] exited (code {rc}) — supervising restart")
+        print(f"[gateway] exited (code {rc}) — supervising restart", flush=True)
         asyncio.create_task(self._supervise_respawn(proc.pid))
 
     async def _supervise_respawn(self, dead_pid: int | None):
@@ -2452,7 +2540,10 @@ _IN_CONTAINER_INSTALL_RE = re.compile(
 # provider has a post_setup hook with an UNSATISFIED install-state predicate.
 # Today `_POST_SETUP_INSTALLED` (hermes_cli/tools_config.py) holds exactly one
 # entry — cua_driver, i.e. Computer Use — but upstream documents that dict as a
-# list to extend, so this will grow silently on future bumps.
+# list to extend, so this will grow silently on future bumps. Re-verified on
+# v2026.8.31: still just cua_driver. Do not confuse it with `_POST_SETUP_READY`
+# in the same file, which DID gain entries (lightpanda) — that one only gates an
+# interactive `hermes tools` prompt and never runs from an HTTP request.
 #
 # This is log-only, deliberately: unlike the two POST paths, we do NOT inject a
 # confirm() here. The existing notice says the install is wiped on redeploy,

--- a/templates/index.html
+++ b/templates/index.html
@@ -1839,6 +1839,43 @@
         </div>
 
         <div class="changelog-entry major">
+          <div class="changelog-date">September 6, 2026</div>
+          <div class="changelog-meta">
+            <span class="meta-box">
+              <span class="meta-label">Git branch</span>
+              <code>release/v2026.8.31/1</code>
+            </span>
+            <span class="meta-box version">
+              <span class="meta-label">Hermes compatible version</span>
+              <code>v2026.8.31</code>
+            </span>
+          </div>
+
+          <div class="changelog-group">Hermes update</div>
+          <ul class="changelog-list">
+            <li>Updated <strong>Hermes Agent to v2026.8.31</strong> (from v2026.8.27). Three more AI providers &mdash; <strong>Tencent TokenPlan</strong>, <strong>Ramp Router</strong> and <strong>Nebius</strong> &mdash; are available from the Hermes Dashboard &rarr; Keys tab, and Kanban boards can now be exported and imported.</li>
+            <li><strong>Scanned PDFs can be read now.</strong> If you have a Firecrawl key saved, pages that are just images of text get sent for OCR instead of coming back empty.</li>
+            <li><strong>Messaging the bot while it is still answering gets a reply.</strong> Hermes used to hold that message silently for up to 30 minutes; it now tells you within a few seconds to resend once the current answer is finished.</li>
+            <li><strong>Connecting a Claude Pro/Max subscription moved out of the dashboard.</strong> Hermes removed that button for policy reasons. Open the <strong>Chat</strong> tab's terminal and run <code>hermes auth add anthropic</code> instead &mdash; plain Anthropic API keys are unaffected.</li>
+          </ul>
+
+          <div class="changelog-group">Changes to support upstream updates</div>
+          <ul class="changelog-list">
+            <li><strong>Reading PDFs and Office files keeps working.</strong> Hermes made its document reader a built-in part of the package. This template used to install its own copy on top, which would now replace it with an older version Hermes then refuses to use &mdash; every PDF, Word, Excel and PowerPoint read would have failed on every deploy, retrying silently in the background forever. The extra copy is gone.</li>
+            <li><strong>Tavily search was removed from Hermes, so Setup offers Keenable instead.</strong> If you had picked Tavily as your search engine in the Hermes <strong>Tools</strong> tab, pick another one there &mdash; searches error until you do. Any Tavily key you saved is left untouched, just unused.</li>
+            <li><strong>Restarting waits for the bot to finish writing to disk.</strong> Hermes now takes longer to shut down when a scheduled job is running, and we were cutting it off part-way &mdash; something Hermes itself now documents as a cause of database corruption.</li>
+            <li><strong>Temporary files stay out of your storage.</strong> Hermes moved the bot's command scratch space onto your data volume; it is back in the container's temporary space, so backups stay small and a restore can't be blocked by leftovers.</li>
+          </ul>
+
+          <div class="changelog-group">Bug fixes</div>
+          <ul class="changelog-list">
+            <li><strong>Switching profiles from the Chat terminal no longer hijacks the bot.</strong> Running <code>hermes profile use</code> could quietly move the bot and the dashboard onto that profile at the next restart, so your approved users and settings appeared to vanish while the bot kept running as someone else.</li>
+            <li><strong>Dashboard sign-in keys saved into the config file can no longer lock you out.</strong> If they ever landed there &mdash; through a restore or the Keys tab &mdash; every Hermes page showed a sign-in error until a redeploy. They are now removed automatically at startup.</li>
+            <li><strong>A broken configuration no longer restarts in a loop.</strong> When the bot cannot start because of a settings problem, the gateway now stops and says so plainly instead of retrying the same failure five times.</li>
+          </ul>
+        </div>
+
+        <div class="changelog-entry major">
           <div class="changelog-date">August 29, 2026</div>
           <div class="changelog-meta">
             <span class="meta-box">
@@ -2074,7 +2111,7 @@ function app() {
   const tools = [
     { key: 'PARALLEL_API_KEY',       label: 'Parallel (search)',         secret: true  },
     { key: 'FIRECRAWL_API_KEY',      label: 'Firecrawl (scraping)',       secret: true  },
-    { key: 'TAVILY_API_KEY',         label: 'Tavily (search)',            secret: true  },
+    { key: 'KEENABLE_API_KEY',       label: 'Keenable (search)',          secret: true  },
     { key: 'FAL_KEY',                label: 'FAL (image gen)',            secret: true  },
     { key: 'BROWSERBASE_API_KEY',    label: 'Browserbase',                secret: true  },
     { key: 'GITHUB_TOKEN',           label: 'GitHub',                     secret: true  },


### PR DESCRIPTION
Audited twice against the v2026.8.27 -> v2026.8.31 diff (all 1,657 changed upstream files). Six functional changes:

- Dockerfile: delete the firecrawl-anydoc==0.1.6 layer. Upstream moved the package into CORE deps at ==0.2.4 and bumped the lazy self-heal pin to match, so our later layer downgraded it and the runtime heal then hard-failed on a --constraint conflict ("No solution found"). Every PDF/Office read would have failed on every deploy, retried every 300s and never succeeding. Reproduced, then verified fixed end-to-end through the agent's read_file tool.
- server.py: replace TAVILY_API_KEY with KEENABLE_API_KEY. Upstream deleted plugins/web/tavily and every reader of that key; a stored web.backend=tavily also errors on every search because _get_backend() is strict with no fallback. An existing key on the volume is preserved, just inert.
- server.py: Gateway.stop() 45s -> 70s, matching upstream's own stop budget (max(60, max(drain, cron+10) + 30)). A SIGKILL mid-WAL-checkpoint is the documented cause of the 2026-08-31 state.db corruption; 70s sits behind hermes' own 60s watchdog, which cleans up its pid file and lock itself.
- server.py: set TERMINAL_TEMP_DIR=/tmp. v2026.8.31 moved terminal/code-exec scratch onto $HERMES_HOME, i.e. the persistent volume, where it also lands in every backup and can block a restore.
- server.py: set HERMES_SUPERVISED_CHILD=1. A `hermes profile use` from the Chat terminal silently re-homed the gateway and dashboard under profiles/<name>; our --external-supervisor flag is parsed too late to prevent it.
- server.py: keep HERMES_DASHBOARD_BASIC_AUTH_* out of .env, at the write chokepoint as well as at boot. hermes loads .env with override=True after the env we pass, so a stray value there made the dashboard accept a different password and 401 the template's own - verified live, and masked by a persisted session until the next re-login.
- server.py: exit 78 (fatal config) no longer respawns, matching upstream's RestartPreventExitStatus=78. Unexpected exits now also reach railway logs.

Verified unchanged: WebSocket allowlist and SPA socket set, host stripping, the auth-gate pairing and password-login contract, install-method refusal, exit-75, --replace guards, pairing resolution, backup constants, state.db schema 26 (a v2026.8.27 archive restores unmigrated).

Validated in Docker on a fresh volume and on a v2026.8.27 volume upgraded in place: Chat/PTY, console, kanban and gateway sockets, PDF read, web search, backup + restore, gateway restart, redeploy survival.