### PR TITLE
Upgrade Hermes Agent to v2026.9.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,144 @@ release.
 
 ---
 
+## release/v2026.9.11/1 — September 12, 2026
+**Hermes v2026.9.11 · major (Hermes upgrade, from v2026.8.31)**
+
+Upstream's "September decomposition" (PR #102117) split nearly every large module
+into focused files, so ~100% of the source churn is code movement. Zero files in
+`hermes_cli/`, `gateway/`, `tools/` or `agent/` are byte-identical; the findings
+below were verified by executing the new tree, not by reading the diff.
+
+### Hermes update
+- Hermes Agent **v2026.8.31 → v2026.9.11** (package 0.21.0 → 0.21.2).
+- **`session_reset` was RETIRED.** `SessionResetPolicy` is now documented as an
+  "inert legacy value type … Gateway configuration and session lifecycle do not
+  consume this datatype" (`gateway/config.py`), `default_reset_policy` went from
+  10 references in `gateway/config.py` to 0, and the key left hermes'
+  known-root-keys list. Conversations persist until an explicit `/new`/`/reset`.
+- **`sessions.auto_prune` False → True** (`config_defaults.py`), with
+  `retention_days: 90`, `min_interval_hours: 24`, `vacuum_after_prune: true`,
+  `min_vacuum_interval_days: 30`. Inherited by every existing volume through the
+  config deep-merge, with no migration and no notice. Only ENDED sessions are
+  deleted — open, pinned and mid-turn rows are never touched. **Reachability on
+  this template is narrower than the config comment implies:** the sole caller is
+  `cli.py:_run_state_db_auto_maintenance`, invoked from
+  `HermesCLI._init_session_store` (`cli.py:2862`), and `HermesCLI` is constructed
+  in exactly two places — `cli.py:4262` (the CLI entry point) and
+  `tui_gateway/slash_worker.py:111` (one worker per TUI session). Neither
+  `gateway/`, `cron/` nor `run_agent` builds it, so a deployment whose users only
+  talk to the bot over Telegram never triggers the sweep; opening the Chat tab
+  does. All knobs are config.yaml-only — there is no env-var reader for any of
+  them, so the template would have to pin it in `write_config_yaml()` (the way it
+  used to pin `session_reset`) to change the default. Left as upstream ships it:
+  there is no fresh-vs-existing divergence here (both inherit the same default),
+  and upstream reports multi-GB `state.db` growth within weeks without it.
+- **`tool_loop_guardrails.non_interactive_hard_stop_enabled: True`** (new).
+  `agent/tool_guardrails.py:_is_non_interactive_platform()` treats every platform
+  outside `{cli, tui, desktop, acp, subagent, api_server}` as unattended and
+  force-sets `hard_stop_enabled`, so a gateway turn now HALTS on a looping tool
+  (exact_failure 5, same_tool_failure 8, idempotent_no_progress 5).
+- **`plugins/web/tavily` was RESTORED** after v2026.8.31 deleted it;
+  `tools/tool_backend_helpers.py` now carries an empty `REMOVED_BACKENDS`
+  registry whose comment names the revert. `plugins/web/perplexity` and
+  `plugins/image_gen/meta-ai` are new. No plugin was removed this bump.
+- **Autodetect ladder reordered** (`tools/web_tools.py:_get_backend`): `tavily`
+  and `perplexity` now head the list, ahead of `exa`/`parallel`/`keenable`. Only
+  reached on a never-configured install; a stored selection is still returned
+  strictly.
+- **`hermes_startup_watchdog.py` (new).** Armed at import for the adjacent argv
+  pair `gateway run` — our exact spawn — it dumps all-thread stacks and
+  `os._exit(75)`s a gateway that has not reached a live event loop in 300s. 75 is
+  the planned-restart code this supervisor already respawns on, so a pre-loop
+  wedge now self-heals. Not armed for `dashboard`/`backup`/`import`.
+- **`is_global_startup_conflict()` (new, `gateway/restart.py`).** A
+  `<scope>_lock` / `lock_conflict` fatal error is emitted `retryable=True` for
+  mid-run reconnects but is now forced NON-retryable at startup
+  (`run_startup.py:1099`). With `connected_count == 0` — a single-platform
+  deployment, this template's typical shape — that exits **78**, which
+  `Gateway._drain()` deliberately never respawns. Previously it retry-queued and
+  self-healed.
+- **`$HERMES_HOME/shared-state.db` (new).** `gateway/hosted_rooms.py`
+  `default_db_path()` moved off `state.db`; the worker is awaited inline at every
+  gateway start, so the file exists on every deployment. Confirmed live: absent
+  on v2026.8.31, present on v2026.9.11. Existing Group Chat state is NOT migrated.
+- **`hermes backup` gained `-k/--keep` (default 3)** which DELETES older
+  `hermes-backup-*.zip` in the output directory. Both template call sites use
+  names that do not match that prefix, so the sweep is inert here.
+- **Plugin-import compat layer expires 2026-09-14.** `hermes_cli/plugin_compat.py`
+  compares `date.today()`, so a pinned image changes behaviour by calendar date.
+  `plugins_loader.py` then refuses to load an EXTERNAL plugin whose source
+  imports a moved internal path; bundled plugins are exempt
+  (`_scan_root` returns None for `source == "bundled"`). Escape hatch:
+  `plugins.allow_deprecated_imports: true`.
+
+### Changes to support upstream updates
+- `Dockerfile`: `ARG HERMES_REF` → `v2026.9.11`. Also re-dated the
+  `--exclude-newer` escape-hatch floor: `nemo-relay` moved `>=0.7.1` (2026-08-07)
+  → `>=0.8.3,<0.9` (0.8.3 published 2026-09-02), so the documented recovery
+  procedure would have failed as written.
+- `server.py` `ENV_VARS` + `templates/index.html`: **`TAVILY_API_KEY` restored**
+  (optional — Tavily works keyless once selected) and **`PERPLEXITY_API_KEY`
+  added** (required; no keyless tier).
+- `server.py` `write_config_yaml()`: dropped the `session_reset.mode = "both"`
+  pin. Unknown top-level keys are deliberately un-warned upstream, so it would
+  have failed silently as a dead key on disk.
+- `server.py` `_BACKUP_EXCLUDED_ROOT_DIRS` + `_in_excluded_root_dir()` (new):
+  mirrors upstream's **second** exclusion mechanism (`_EXCLUDED_ROOT_DIRS` +
+  `_in_excluded_root_dir`, `hermes_cli/backup.py`), which skips `models`,
+  `runtimes` and `node` only at the root of `HERMES_HOME` and at
+  `profiles/<name>/`. Root-scoped, not flat — `skills/foo/models/` must still be
+  backed up. Without the mirror a `*.db` under any of the three is demanded by
+  `_live_db_names()` while `hermes backup` omits it, and the false "incomplete"
+  ABORTS a restore. Unit-tested against upstream's own function across 14 paths.
+- `server.py` `build_hermes_env()`: `HERMES_GATEWAY_LOCK_DIR=/tmp/hermes-gateway-locks`
+  (`setdefault`). Hermes' per-token locks are machine-local by intent but default
+  to `$HOME/.local/state/hermes/gateway-locks`, and `HOME=/data` puts them on the
+  volume where they outlive a redeploy — `start.sh` only sweeps
+  `gateway.pid`/`.lock`/`.sock`. With the new exit-78 rule above, a stale token
+  lock is no longer a recoverable state, so it must not be able to persist.
+
+### Bug fixes
+- **The crash-loop guard could never fire on a slow loop.** `_supervise_respawn`
+  pruned `_recent_exits` on a fixed 120s window and needed 5 entries, so any
+  failure cycle slower than ~24s dropped its own history every boot and the
+  counter never advanced — the exact defect upstream names in its new
+  `gateway/restart_loop_guard.py`. v2026.9.11's 300s startup watchdog makes that
+  reachable: respawn every 5 minutes, forever, with Status reading "running".
+  Added `RESPAWN_CHAIN_GAP_S` / `RESPAWN_CHAIN_UPTIME_S` / `RESPAWN_MAX_CHAIN`,
+  which chain exits that are both close together AND short-lived. Simulated
+  across 8 scenarios: fast loops still trip at 6 exits, the 300s loop now trips
+  at 9, and healthy patterns (daily crash, hourly `/restart`, 12-minute manual
+  restarts) never trip. A give-up now also `print()`s to `railway logs`.
+
+### Housekeeping
+- Documented, at both `hermes backup` call sites, that only the output filename
+  keeps the new `--keep 3` auto-prune inert.
+- `README.md`: pinned version ×2 and the supported-tools list.
+
+### Verified unchanged (audited, no action)
+Install extras (all 9 still exist; resolve executed on x86_64 and aarch64) ·
+subprocess argv (all five parsed against the real `_build_cli_parser`, with a
+negative control) · the WebSocket route set (enumerated from the live
+`app.routes` on both tags — 7 unique paths, identical) · `HOP_BY_HOP`
+host-stripping and the loopback Host gate · the auth gate, `resolve_public_url`
+and the four `HERMES_DASHBOARD_BASIC_AUTH_*` keys · `ws_max_size` 384 MiB and
+loopback `ws_ping_interval=None` · pairing directory resolution and the
+pending/approved JSON schema (agreement re-proved inside the container on a
+fresh volume) · `gateway.pid`/`.lock`/`.sock`, exit codes 75/78, container
+markers · `detect_install_method` precedence and the Update-button refusal ·
+`_EXCLUDED_DIRS`, `_IMPORT_SKIP_NAMES`, `_validate_backup_zip`, the `--force`
+prompt · `HERMES_SUPERVISED_CHILD`, `HERMES_GATEWAY_MAX_STARTS`,
+`HERMES_RESTART_AFTER_TURN_TIMEOUT`, `TERMINAL_TEMP_DIR` precedence ·
+`firecrawl-anydoc==0.2.4` agreeing in core deps and `tools/lazy_deps.py` ·
+`_POST_SETUP_INSTALLED` (still only `cua_driver`) · `_PROFILE_MANAGED_ENV_KEYS`
+(still the 6 ACP/Copilot keys) · `KNOWN_PROVIDER_KEY_PREFIXES` ·
+`web_dist` outDir, `HERMES_TUI_DIR`, node/npm engines · `cron_drain_timeout` 30,
+`gateway_startup_warmup_timeout` 20, `gateway_turn_lease_timeout` 5 · bundled
+skills (none removed).
+
+---
+
 ## release/v2026.8.31/1 — September 6, 2026
 **Hermes v2026.8.31 · major (Hermes upgrade, from v2026.8.27)**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 # newest tag (format `vYYYY.M.D`, optionally with a `.PATCH` suffix, e.g.
 # `v2026.5.29.2`) and update the default below. Use `main` only if you accept
 # that every rebuild can pull arbitrary new upstream commits.
-ARG HERMES_REF=v2026.8.31
+ARG HERMES_REF=v2026.9.11
 
 # Persist the build arg into the runtime env so the admin UI can display which
 # Hermes release this image actually pins. Reading it (rather than hardcoding a
@@ -61,12 +61,13 @@ RUN apt-get update && \
 # exclude-newer="14 days" can fail a build on a fresh dep — override with
 # `uv pip install --exclude-newer <date>`.
 #
-# v2026.8.13 made that escape hatch sharper: nemo-relay's floor moved to
-# >=0.7.1 (published 2026-08-07), which only resolves because upstream lists
-# it in exclude-newer-package. A manual `--exclude-newer <date>` re-imposes a
-# GLOBAL cutoff, so any date before 2026-08-07 leaves nemo-relay>=0.7.1
-# unsatisfiable and hard-fails the build. Same trap for cryptography==50.0.0
-# and h2 4.4.1. If you ever need that flag, pass a date >= 2026-08-07.
+# v2026.8.13 made that escape hatch sharper, and v2026.9.11 moved the floor
+# again: nemo-relay is now >=0.8.3,<0.9 (0.8.3 published 2026-09-02), which
+# only resolves because upstream lists it in exclude-newer-package. A manual
+# `--exclude-newer <date>` re-imposes a GLOBAL cutoff, so any date before
+# 2026-09-02 leaves nemo-relay>=0.8.3 unsatisfiable and hard-fails the build.
+# Same trap for cryptography==50.0.0 and h2 4.4.1. Re-read this floor on every
+# bump — it tracks whatever nemo-relay pin the pinned tag carries.
 RUN git clone --depth 1 --branch ${HERMES_REF} https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent && \
     cd /opt/hermes-agent && \
     uv pip install --system --no-cache -e ".[all,messaging,tts-premium,honcho,bedrock,anthropic,edge-tts,hindsight,vision]" && \

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Telegram, Discord, Slack, WhatsApp, Email, Mattermost, Matrix
 
 ## Supported Tool Integrations
 
-Parallel (search), Firecrawl (scraping), Keenable (search), FAL (image gen), Browserbase, GitHub, OpenAI Voice (Whisper/TTS), Honcho (memory)
+Parallel (search), Firecrawl (scraping), Keenable (search), Tavily (search), Perplexity (search), FAL (image gen), Browserbase, GitHub, OpenAI Voice (Whisper/TTS), Honcho (memory)
 
 ## Architecture
 
@@ -120,9 +120,9 @@ Open `http://localhost:8080` and log in with `admin` / `changeme`.
 
 ## Updating Hermes
 
-This template pins a specific Hermes Agent release in the `Dockerfile` (`ARG HERMES_REF`, currently `v2026.8.31`). To upgrade:
+This template pins a specific Hermes Agent release in the `Dockerfile` (`ARG HERMES_REF`, currently `v2026.9.11`). To upgrade:
 
-- **Recommended:** set a `HERMES_REF` service variable in Railway to any upstream [release tag](https://github.com/NousResearch/hermes-agent/releases) (e.g. `v2026.8.31`), then redeploy. It's passed in as a Docker build arg and overrides the Dockerfile default — no code change needed.
+- **Recommended:** set a `HERMES_REF` service variable in Railway to any upstream [release tag](https://github.com/NousResearch/hermes-agent/releases) (e.g. `v2026.9.11`), then redeploy. It's passed in as a Docker build arg and overrides the Dockerfile default — no code change needed.
 - **Or** bump `ARG HERMES_REF` in the `Dockerfile` and redeploy.
 
 The "Update" button inside the Hermes dashboard is a **no-op on Railway** (it detects a container install and refuses) — the image is immutable, so a runtime self-update wouldn't survive a redeploy. Bump `HERMES_REF` and redeploy instead. When jumping releases, re-check that the Dockerfile's install extras still match upstream's `pyproject.toml`.

--- a/server.py
+++ b/server.py
@@ -294,10 +294,20 @@ ENV_VARS = [
     ("CUSTOM_PROVIDER_NAME",     "Custom Provider name",     "custom",    False),
     ("PARALLEL_API_KEY",         "Parallel (search)",        "tool",      True),
     ("FIRECRAWL_API_KEY",        "Firecrawl (scrape)",       "tool",      True),
-    # Keenable replaced Tavily in v2026.8.31 — upstream DELETED plugins/web/tavily
-    # and every TAVILY_API_KEY reader with it, so the old field wrote a key
-    # nothing reads. Keenable is the vendor hermes' own setup now offers instead.
     ("KEENABLE_API_KEY",         "Keenable (search)",        "tool",      True),
+    # Tavily was DELETED in v2026.8.31 (so we dropped this field) and RESTORED in
+    # v2026.9.11 — upstream reverted the removal, and tools/tool_backend_helpers.py
+    # now carries an empty REMOVED_BACKENDS registry naming that revert. Anyone who
+    # had selected Tavily as their web backend before the deletion has had a hard
+    # error on every search since, because tools/web_tools.py:_get_backend() returns
+    # a stored selection strictly with no fallback; restoring the field lets them see
+    # and re-enter the key. Optional by design: Tavily also works keyless once it is
+    # the selected backend, so an empty value here is a valid state.
+    ("TAVILY_API_KEY",           "Tavily (search)",          "tool",      True),
+    # New vendor in v2026.9.11 (plugins/web/perplexity). Key is REQUIRED — unlike
+    # Tavily/Keenable it has no keyless tier — and it now sits second in the
+    # autodetect ladder, so a key here is picked up on a never-configured install.
+    ("PERPLEXITY_API_KEY",       "Perplexity (search)",      "tool",      True),
     ("FAL_KEY",                  "FAL (image gen)",          "tool",      True),
     ("BROWSERBASE_API_KEY",      "Browserbase key",          "tool",      True),
     ("BROWSERBASE_PROJECT_ID",   "Browserbase project",      "tool",      False),
@@ -581,18 +591,16 @@ def write_config_yaml(data: dict[str, str], *, reset_model: bool = False) -> Non
     merged_agent.setdefault("max_iterations", 50)
     merged["agent"] = merged_agent
 
-    # Pin the conversation auto-reset policy so it doesn't depend on volume age.
-    # start.sh seeds cli-config.yaml.example only on a FRESH volume, and
-    # v2026.7.20 flipped that example (and SessionResetPolicy's own default)
-    # from "both" to "none" — so without this an existing deployment keeps
-    # resetting while a newly deployed one never does, from identical code.
-    # We keep "both" (idle + daily): it bounds context growth and preserves the
-    # agent's one turn to persist memories/skills before a wipe.
-    # setdefault, not assignment — unlike terminal.backend this is a user
-    # preference, so a value chosen in hermes' own settings survives.
-    merged_session_reset = dict(merged.get("session_reset") if isinstance(merged.get("session_reset"), dict) else {})
-    merged_session_reset.setdefault("mode", "both")
-    merged["session_reset"] = merged_session_reset
+    # NOTE: we used to pin `session_reset.mode = "both"` here so conversation
+    # auto-reset didn't depend on volume age. v2026.9.11 RETIRED the feature:
+    # SessionResetPolicy is now documented as an "inert legacy value type ...
+    # Gateway configuration and session lifecycle do not consume this datatype"
+    # (gateway/config.py), the config->gateway bridge that read it is gone
+    # (`default_reset_policy` went from 10 references to 0), and hermes dropped
+    # `session_reset` from its own known-root-keys list. Writing it now only
+    # leaves a dead key on disk — unknown top-level keys are deliberately not
+    # warned about, so it would fail silently. Conversations persist until an
+    # explicit /new or /reset; context growth is handled by compression.
 
     merged["data_dir"] = HERMES_HOME
 
@@ -784,6 +792,19 @@ def build_hermes_env() -> dict[str, str]:
     # (main.py `_under_gateway_supervisor`), never by is_gateway_supervisor_process()
     # or the s6 redirect, so it cannot alter the exit-75 restart contract.
     env.setdefault("HERMES_SUPERVISED_CHILD", "1")
+    # Keep hermes' per-token gateway locks OFF the Railway volume. They are
+    # MACHINE-local by intent (gateway/status.py `_get_lock_dir`), but they
+    # default to $HOME/.local/state/hermes/gateway-locks and the Dockerfile sets
+    # HOME=/data — so they land on the volume and outlive a redeploy, while
+    # start.sh only sweeps gateway.pid/.lock/.sock under $HERMES_HOME. That
+    # matters more since v2026.9.11: `is_global_startup_conflict`
+    # (gateway/restart.py, new) reclassifies a `<scope>_lock` conflict at STARTUP
+    # from retryable to fatal, so a single-platform deployment whose one adapter
+    # hits it exits 78 — which this supervisor deliberately never respawns. One
+    # container runs exactly one gateway, so the lock only ever needs to live as
+    # long as the container. /tmp gives it that and nothing more; hermes mkdirs
+    # the path itself. setdefault, so a Railway variable can move it back.
+    env.setdefault("HERMES_GATEWAY_LOCK_DIR", "/tmp/hermes-gateway-locks")
     # Drop inbound values first: the template is the only thing allowed to
     # decide these (this pop covers a Railway service variable, which lands in
     # our own os.environ; _sanitize_env_file() covers the .env file).
@@ -1345,6 +1366,23 @@ RESPAWN_MAX_IN_WIN = 5       # give up auto-restart after this many exits in win
 RESPAWN_BASE_DELAY = 2.0     # first backoff (seconds)
 RESPAWN_MAX_DELAY  = 30.0    # backoff cap
 
+# The window above only ever sees loops FASTER than itself: a failure cycle
+# longer than RESPAWN_WINDOW_S / RESPAWN_MAX_IN_WIN (~24s) drops its own history
+# on the next prune, so the counter never reaches the threshold and the guard
+# never fires. v2026.9.11 made that reachable: hermes_startup_watchdog.py (new)
+# os._exit(75)s a gateway that hasn't reached a live event loop in 300s, which
+# is a ~5-minute cycle — the bot never answers, /health stays 200, and the only
+# symptom is one log line every 5 minutes, forever. Upstream hit the same shape
+# and says so in gateway/restart_loop_guard.py: "A fixed-window prune only sees
+# cycles faster than the window (a slower loop drops its history every boot and
+# never trips)". So we also CHAIN exits that are close together AND short-lived.
+# Both conditions matter: the gap bound keeps unrelated failures days apart from
+# chaining, and the uptime bound means a gateway that actually served for a
+# while (an in-band /restart, say) breaks the chain instead of extending it.
+RESPAWN_CHAIN_GAP_S    = 1800   # exits further apart than this start a new chain
+RESPAWN_CHAIN_UPTIME_S = 600    # an exit after MORE uptime than this breaks the chain
+RESPAWN_MAX_CHAIN      = 8      # give up after this many chained short-lived exits
+
 
 # v2026.8.27's cross-profile ownership gate (gateway/run.py) logs this and
 # exits 1 rather than displacing a PID it cannot attribute to this HERMES_HOME.
@@ -1364,6 +1402,11 @@ class Gateway:
         self._stopping = False
         # Monotonic timestamps of recent unexpected exits (crash-loop guard).
         self._recent_exits: list[float] = []
+        # Slow-loop guard: consecutive short-lived exits, and when the last one
+        # landed. Monotonic (never wall clock) so an NTP step can't extend a chain.
+        self._exit_chain = 0
+        self._last_exit_at: float | None = None
+        self._started_monotonic: float | None = None
 
     async def start(self, *, reset_budget: bool = True):
         if self.proc and self.proc.returncode is None:
@@ -1373,6 +1416,8 @@ class Gateway:
         # accumulating toward the give-up threshold.
         if reset_budget:
             self._recent_exits.clear()
+            self._exit_chain = 0
+            self._last_exit_at = None
         self.state = "starting"
         self._stopping = False
         try:
@@ -1413,6 +1458,7 @@ class Gateway:
             )
             self.state = "running"
             self.started_at = time.time()
+            self._started_monotonic = time.monotonic()
             asyncio.create_task(self._drain(self.proc))
         except Exception as e:
             self.state = "error"
@@ -1498,16 +1544,31 @@ class Gateway:
         now = time.monotonic()
         self._recent_exits = [t for t in self._recent_exits if now - t < RESPAWN_WINDOW_S]
         self._recent_exits.append(now)
-        if len(self._recent_exits) > RESPAWN_MAX_IN_WIN:
+        # Chain short-lived exits that arrive close together (see RESPAWN_CHAIN_*).
+        uptime = now - self._started_monotonic if self._started_monotonic is not None else 0.0
+        gap = now - self._last_exit_at if self._last_exit_at is not None else None
+        if uptime > RESPAWN_CHAIN_UPTIME_S or (gap is not None and gap > RESPAWN_CHAIN_GAP_S):
+            self._exit_chain = 1
+        else:
+            self._exit_chain += 1
+        self._last_exit_at = now
+        if len(self._recent_exits) > RESPAWN_MAX_IN_WIN or self._exit_chain > RESPAWN_MAX_CHAIN:
             self.state = "crashed"
-            self.logs.append(
-                f"[gateway] crash-looping ({len(self._recent_exits)} exits in "
-                f"{RESPAWN_WINDOW_S}s) — giving up auto-restart. Fix the provider/"
-                f"model in the admin UI, then Start/Restart the gateway."
-            )
+            if self._exit_chain > RESPAWN_MAX_CHAIN:
+                detail = (f"{self._exit_chain} short-lived exits in a row "
+                          f"(each under {RESPAWN_CHAIN_UPTIME_S}s of uptime)")
+            else:
+                detail = f"{len(self._recent_exits)} exits in {RESPAWN_WINDOW_S}s"
+            msg = (f"[gateway] crash-looping ({detail}) — giving up auto-restart. "
+                   f"Check the Logs panel, fix the cause, then Start/Restart the gateway.")
+            self.logs.append(msg)
+            # print() too: a give-up is the terminal state of the supervisor and
+            # must be visible in `railway logs` without opening /setup.
+            print(msg, flush=True)
             return
-        delay = min(RESPAWN_BASE_DELAY * 2 ** (len(self._recent_exits) - 1), RESPAWN_MAX_DELAY)
-        self.logs.append(f"[gateway] restarting in {int(delay)}s (attempt {len(self._recent_exits)})")
+        attempt = max(len(self._recent_exits), self._exit_chain)
+        delay = min(RESPAWN_BASE_DELAY * 2 ** (attempt - 1), RESPAWN_MAX_DELAY)
+        self.logs.append(f"[gateway] restarting in {int(delay)}s (attempt {attempt})")
         await asyncio.sleep(delay)
         # Re-check the deliberate-lifecycle conditions AFTER the backoff sleep: a
         # Stop, Reset, or shutdown issued during the wait must win over the respawn.
@@ -2238,10 +2299,12 @@ def _sweep_stale_backup_tmpdirs() -> None:
         pass
 
 
-# Mirrors hermes' own _EXCLUDED_DIRS (hermes_cli/backup.py, v2026.8.13) so
-# _live_db_names() can never demand a database hermes deliberately skips. That
-# direction matters: a false "incomplete" ABORTS a restore, which is strictly
-# worse than the gap it closes. Re-check this against upstream on a bump.
+# Mirrors hermes' own _EXCLUDED_DIRS (hermes_cli/backup.py, re-verified
+# byte-identical at v2026.9.11) so _live_db_names() can never demand a database
+# hermes deliberately skips. That direction matters: a false "incomplete" ABORTS
+# a restore, which is strictly worse than the gap it closes. Re-check this
+# against upstream on a bump — and check _BACKUP_EXCLUDED_ROOT_DIRS below too,
+# because upstream now has TWO exclusion mechanisms, not one.
 _BACKUP_EXCLUDED_DIRS = {
     "hermes-agent", "__pycache__", ".git", "node_modules", "backups",
     "checkpoints", ".venv", "venv", "site-packages",
@@ -2250,6 +2313,33 @@ _BACKUP_EXCLUDED_DIRS = {
     # live browser-profile dirs (Chromium holds their SQLite files locked).
     "state-snapshots", "browser-profiles", "browser-profile",
 }
+
+# v2026.9.11 added a SECOND mechanism upstream (_EXCLUDED_ROOT_DIRS +
+# _in_excluded_root_dir in hermes_cli/backup.py): three trees skipped ONLY at the
+# top of HERMES_HOME (and at profiles/<name>/), holding machine-scoped bulk data
+# the new local-model runtime downloads — GGUF weights, llama.cpp binaries and a
+# managed Node install, which upstream's own comment calls "routinely tens to
+# hundreds of GB". Root-scoped, not flat: a skills/foo/models/ directory is still
+# backed up, so mirroring these into _BACKUP_EXCLUDED_DIRS would over-exclude.
+# Without this mirror a *.db under any of the three is demanded by
+# _live_db_names() while `hermes backup` deliberately omits it, and the resulting
+# false "incomplete" ABORTS a restore.
+_BACKUP_EXCLUDED_ROOT_DIRS = {"models", "runtimes", "node"}
+
+
+def _in_excluded_root_dir(rel: Path) -> bool:
+    """Mirror of hermes' `_in_excluded_root_dir`: top level only, plus per-profile.
+
+    `rel` is the path relative to HERMES_HOME, filename included — same shape
+    upstream passes, so the `>= 3` profile check lines up with theirs.
+    """
+    parts = rel.parts
+    if not parts:
+        return False
+    return (
+        parts[0] in _BACKUP_EXCLUDED_ROOT_DIRS
+        or (len(parts) >= 3 and parts[0] == "profiles" and parts[2] in _BACKUP_EXCLUDED_ROOT_DIRS)
+    )
 
 
 def _live_db_names() -> set[str]:
@@ -2276,10 +2366,12 @@ def _live_db_names() -> set[str]:
             try:
                 if not path.is_file():
                     continue
-                parents = path.relative_to(root).parts[:-1]
+                rel = path.relative_to(root)
             except (OSError, ValueError):
                 continue
-            if any(part in _BACKUP_EXCLUDED_DIRS for part in parents):
+            if any(part in _BACKUP_EXCLUDED_DIRS for part in rel.parts[:-1]):
+                continue
+            if _in_excluded_root_dir(rel):
                 continue
             found.add(path.name)
     except OSError:
@@ -2327,6 +2419,11 @@ async def api_backup_download(request: Request) -> Response:
     async with backup_lock:
         tmp_dir = tempfile.mkdtemp(prefix="hermes-backup-")
         zip_path = Path(tmp_dir) / "backup.zip"
+        # NOTE: v2026.9.11 gave `hermes backup` a `-k/--keep` (default 3) that
+        # DELETES older archives in the output directory. It is gated on the
+        # output filename starting with hermes' own "hermes-backup-" prefix, so
+        # "backup.zip" here is inert — but that is the only thing making it
+        # inert. Do not rename these outputs to the upstream prefix shape.
         rc, output = await _run_hermes_cli("backup", "-o", str(zip_path))
         if _is_backup_busy(rc, output):
             shutil.rmtree(tmp_dir, ignore_errors=True)
@@ -2440,6 +2537,9 @@ async def api_backup_restore(request: Request) -> Response:
             # secrets suffix avoids a same-second collision silently clobbering
             # a distinct prior snapshot (two restores fired back-to-back).
             snap_path = BACKUP_DIR / f"pre-restore-{int(time.time())}-{secrets.token_hex(4)}.zip"
+            # "pre-restore-*" deliberately does not match hermes' own
+            # "hermes-backup-" prefix, so its v2026.9.11 `--keep 3` auto-prune
+            # never touches these; _prune_pre_restore_snapshots() owns them.
             rc, output = await _run_hermes_cli("backup", "-o", str(snap_path))
             # A lock collision is transient and retryable — say so, instead of
             # reporting it as "the backup command failed", which reads as data

--- a/templates/index.html
+++ b/templates/index.html
@@ -1839,6 +1839,44 @@
         </div>
 
         <div class="changelog-entry major">
+          <div class="changelog-date">September 12, 2026</div>
+          <div class="changelog-meta">
+            <span class="meta-box">
+              <span class="meta-label">Git branch</span>
+              <code>release/v2026.9.11/1</code>
+            </span>
+            <span class="meta-box version">
+              <span class="meta-label">Hermes compatible version</span>
+              <code>v2026.9.11</code>
+            </span>
+          </div>
+
+          <div class="changelog-group">Hermes update</div>
+          <ul class="changelog-list">
+            <li>Updated <strong>Hermes Agent to v2026.9.11</strong> (from v2026.8.31). Two web-search providers join Setup &mdash; <strong>Tavily</strong>, which Hermes removed last release and has now restored, and <strong>Perplexity</strong>, which is new.</li>
+            <li><strong>The bot gives up on work it cannot finish.</strong> A tool call that keeps failing used to be retried until the turn ran out; it now stops after a few attempts and says so, which caps what a stuck job can cost you.</li>
+            <li><strong>Conversations no longer reset on their own.</strong> Hermes retired the automatic idle and daily reset &mdash; a chat now continues until you send <code>/new</code> or <code>/reset</code>.</li>
+            <li><strong>Finished conversations older than 90 days now get tidied up.</strong> Hermes turned this on to stop the chat history growing without bound. Open, pinned and in-progress chats are never touched, and the sweep only runs when something starts a Hermes command line &mdash; opening the <strong>Chat</strong> tab, for instance &mdash; at most once a day.</li>
+            <li><strong>A bot that hangs while starting now recovers by itself.</strong> Hermes watches its own startup and restarts if it wedges, instead of sitting there looking healthy while answering nothing.</li>
+            <li><strong>Group chat state starts fresh.</strong> Hermes moved that data into a new file and does not carry the old one across.</li>
+            <li><strong>If you installed a community plugin, check it still loads.</strong> Hermes reorganised its internals and retired the old compatibility paths on September 14. Update the plugin, or set <code>plugins.allow_deprecated_imports: true</code> from the Hermes <strong>Config</strong> tab.</li>
+          </ul>
+
+          <div class="changelog-group">Changes to support upstream updates</div>
+          <ul class="changelog-list">
+            <li><strong>Tavily is back in Setup, and Perplexity is there too.</strong> If you had picked Tavily as your search engine before it was removed, searches have been failing since &mdash; they work again, and your saved key was never touched.</li>
+            <li><strong>Restores keep working alongside Hermes&rsquo; new local-model storage.</strong> Hermes added folders for downloaded models and runtimes that it deliberately leaves out of a backup; this template now agrees with it, so a restore can no longer be refused over a file that was never meant to be in the archive.</li>
+            <li><strong>A bot token already in use can no longer keep you offline after a redeploy.</strong> Hermes now treats that as a fatal startup error rather than retrying, so the record that tracks it is kept out of your storage where it cannot outlive a restart.</li>
+          </ul>
+
+          <div class="changelog-group">Bug fixes</div>
+          <ul class="changelog-list">
+            <li><strong>A bot that fails slowly now stops retrying and tells you.</strong> The restart guard only counted failures that repeated within two minutes, so a slower loop could restart every five minutes indefinitely while Status still read &ldquo;running&rdquo;.</li>
+            <li><strong>Stopped writing a setting Hermes no longer reads.</strong> The conversation-reset policy is now inert upstream, so saving it only left a dead entry in your config file.</li>
+          </ul>
+        </div>
+
+        <div class="changelog-entry major">
           <div class="changelog-date">September 6, 2026</div>
           <div class="changelog-meta">
             <span class="meta-box">
@@ -2112,6 +2150,8 @@ function app() {
     { key: 'PARALLEL_API_KEY',       label: 'Parallel (search)',         secret: true  },
     { key: 'FIRECRAWL_API_KEY',      label: 'Firecrawl (scraping)',       secret: true  },
     { key: 'KEENABLE_API_KEY',       label: 'Keenable (search)',          secret: true  },
+    { key: 'TAVILY_API_KEY',         label: 'Tavily (search)',            secret: true  },
+    { key: 'PERPLEXITY_API_KEY',     label: 'Perplexity (search)',        secret: true  },
     { key: 'FAL_KEY',                label: 'FAL (image gen)',            secret: true  },
     { key: 'BROWSERBASE_API_KEY',    label: 'Browserbase',                secret: true  },
     { key: 'GITHUB_TOKEN',           label: 'GitHub',                     secret: true  },


### PR DESCRIPTION
Hermes v2026.8.31 -> v2026.9.11 (package 0.21.0 -> 0.21.2). Upstream's "September decomposition" (PR #102117) split nearly every large module, so ~100% of the source churn is code movement; the findings below were verified by executing the new tree rather than by reading the diff.

Template changes:

- Dockerfile: ARG HERMES_REF -> v2026.9.11. Re-dated the --exclude-newer escape-hatch floor (nemo-relay >=0.7.1/2026-08-07 -> >=0.8.3/2026-09-02); the documented recovery procedure would have failed as written.
- ENV_VARS + setup UI: TAVILY_API_KEY restored (upstream reverted the v2026.8.31 deletion; anyone who had Tavily selected has been hard-erroring on every search since) and PERPLEXITY_API_KEY added.
- write_config_yaml(): dropped the session_reset pin. SessionResetPolicy is now an "inert legacy value type" upstream and default_reset_policy went from 10 references to 0, so the write only left a dead key on disk.
- _BACKUP_EXCLUDED_ROOT_DIRS + _in_excluded_root_dir(): mirror upstream's SECOND exclusion mechanism ({models, runtimes, node}, root-scoped only). Without it a *.db under any of the three is demanded by _live_db_names() while hermes omits it, and the false "incomplete" ABORTS a restore. Unit-tested against upstream's own function across 14 paths.
- build_hermes_env(): HERMES_GATEWAY_LOCK_DIR=/tmp/hermes-gateway-locks. Per-token locks are machine-local by intent but default under $HOME, and HOME=/data puts them on the volume where start.sh's sweep never reaches them. v2026.9.11's is_global_startup_conflict() turns a startup lock conflict into exit 78, which this supervisor never respawns, so a stale lock must not be able to outlive a redeploy.
- Crash-loop guard: the fixed 120s window could only ever see loops faster than itself, so v2026.9.11's 300s startup watchdog produced an unbounded 5-minute respawn loop with Status still reading "running". Added RESPAWN_CHAIN_GAP_S / RESPAWN_CHAIN_UPTIME_S / RESPAWN_MAX_CHAIN, chaining exits that are both close together and short-lived. Simulated across 8 scenarios: fast loops still trip at 6, the 300s loop now trips at 9, and healthy patterns (daily crash, hourly /restart) never trip.

Verified on a local build against a fresh volume: image builds, gateway starts on MiniMax and answers end-to-end, backup (370 entries, all four databases) and restore --force both succeed, a planted models/decoy.db is correctly not demanded while skills/foo/models/nested.db still is, new provider keys persist and read back masked, gateway restart recovers in ~4s, and the log scan for 403 / Invalid Host / PID file race / Refusing --replace / Traceback / --tui is clean.